### PR TITLE
Feature/18 errand 등록 시 불필요한 데이터를 받아오는 문제 해결을 위해 ErrandSaveRequestDto 추가

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/AppteamApplication.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/AppteamApplication.java
@@ -1,12 +1,7 @@
 package com.pknuErrand.appteam;
 
-import com.pknuErrand.appteam.domain.errand.Errand;
-import com.pknuErrand.appteam.domain.errand.ErrandRequestDto;
-import com.pknuErrand.appteam.domain.errand.Status;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-import java.sql.Timestamp;
 
 @SpringBootApplication
 public class AppteamApplication {

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -1,9 +1,8 @@
 package com.pknuErrand.appteam.controller.errand;
 
 
-import com.pknuErrand.appteam.domain.errand.ErrandRequestDto;
-import com.pknuErrand.appteam.domain.errand.ErrandResponseDto;
-import com.pknuErrand.appteam.repository.errand.ErrandRepository;
+import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandResponseDto;
+import com.pknuErrand.appteam.domain.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.service.errand.ErrandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,9 +28,9 @@ public class ErrandController {
 
     @Operation(summary = "요청서 등록" , description = "심부름 요청서 등록")
     @PostMapping
-    public ResponseEntity<ErrandResponseDto> createErrand(@RequestBody ErrandRequestDto errandRequestDto) {
+    public ResponseEntity<ErrandResponseDto> createErrand(@RequestBody ErrandSaveRequestDto errandSaveRequestDto) {
         return ResponseEntity.ok()
-                .body(errandService.createErrand(errandRequestDto));
+                .body(errandService.createErrand(errandSaveRequestDto));
     }
 
     @Operation(summary = "요청서 전부 불러오기" , description = "심부름 요청서 전부 불러오기")

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
@@ -5,9 +5,7 @@ import com.pknuErrand.appteam.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-import java.sql.Time;
 import java.sql.Timestamp;
 
 @Getter
@@ -59,17 +57,20 @@ public class Errand {
     @JoinColumn
     private Member erranderNo; // 심부름꾼
 
-    public Errand(ErrandRequestDto requestDto) {
-        this.orderNo = requestDto.getOrderNo();
-        this.title = requestDto.getTitle();
-        this.destination = requestDto.getDestination();
-        this.latitude = requestDto.getLatitude();
-        this.longitude = requestDto.getLongitude();
-        this.due = requestDto.getDue();
-        this.detail = requestDto.getDetail();
-        this.reward = requestDto.getReward();
-        this.isCash = requestDto.isCash();
-        this.status = requestDto.getStatus();
-        this.erranderNo = requestDto.getErranderNo();
+    public Errand(Member orderNo, Timestamp createdDate, String title, String destination,
+                  double latitude, double longitude, Timestamp due, String detail,
+                  int reward, boolean isCash, Status status, Member erranderNo) {
+        this.orderNo = orderNo;
+        this.createdDate = createdDate;
+        this.title = title;
+        this.destination = destination;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.due = due;
+        this.detail = detail;
+        this.reward = reward;
+        this.isCash = isCash;
+        this.status = status;
+        this.erranderNo = erranderNo;
     }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/ErrandBuilder.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/ErrandBuilder.java
@@ -1,0 +1,86 @@
+package com.pknuErrand.appteam.domain.errand;
+
+import com.pknuErrand.appteam.domain.member.Member;
+import jakarta.persistence.*;
+
+import java.sql.Timestamp;
+
+public class ErrandBuilder {
+
+    private Member orderNo;
+    private Timestamp createdDate;
+    private String title;
+    private String destination;
+    private double latitude;
+    private double longitude;
+    private Timestamp due;
+    private String detail;
+    private int reward;
+    private boolean isCash;
+    private Status status;
+    private Member erranderNo;
+
+    public ErrandBuilder orderNo(Member orderNo) {
+        this.orderNo = orderNo;
+        return this;
+    }
+
+    public ErrandBuilder createdDate(Timestamp createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+
+    public ErrandBuilder title(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public ErrandBuilder destination(String destination) {
+        this.destination = destination;
+        return this;
+    }
+
+    public ErrandBuilder latitude(double latitude) {
+        this.latitude = latitude;
+        return this;
+    }
+
+    public ErrandBuilder longitude(double longitude) {
+        this.longitude = longitude;
+        return this;
+    }
+
+    public ErrandBuilder due(Timestamp due) {
+        this.due = due;
+        return this;
+    }
+
+    public ErrandBuilder detail(String detail) {
+        this.detail = detail;
+        return this;
+    }
+
+    public ErrandBuilder reward(int reward) {
+        this.reward = reward;
+        return this;
+    }
+
+    public ErrandBuilder isCash(boolean isCash) {
+        this.isCash = isCash;
+        return this;
+    }
+
+    public ErrandBuilder status(Status status) {
+        this.status = status;
+        return this;
+    }
+
+    public ErrandBuilder erranderNo(Member erranderNo) {
+        this.erranderNo = erranderNo;
+        return this;
+    }
+
+    public Errand build() {
+        return new Errand(orderNo, createdDate, title, destination, latitude, longitude, due, detail, reward, isCash, status, erranderNo);
+    }
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandRequestDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandRequestDto.java
@@ -1,5 +1,6 @@
-package com.pknuErrand.appteam.domain.errand;
+package com.pknuErrand.appteam.domain.errand.defaultDto;
 
+import com.pknuErrand.appteam.domain.errand.Status;
 import com.pknuErrand.appteam.domain.member.Member;
 import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandResponseDto.java
@@ -1,5 +1,7 @@
-package com.pknuErrand.appteam.domain.errand;
+package com.pknuErrand.appteam.domain.errand.defaultDto;
 
+import com.pknuErrand.appteam.domain.errand.Errand;
+import com.pknuErrand.appteam.domain.errand.Status;
 import com.pknuErrand.appteam.domain.member.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/saveDto/ErrandSaveRequestDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/saveDto/ErrandSaveRequestDto.java
@@ -1,0 +1,45 @@
+package com.pknuErrand.appteam.domain.errand.saveDto;
+
+import com.pknuErrand.appteam.domain.errand.Status;
+import com.pknuErrand.appteam.domain.member.Member;
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ErrandSaveRequestDto { // to Entity
+
+    private Long orderNo; // 심부름 시킨사람 pk
+    /**
+     *  pk 를 통해 가져온다.
+     */
+
+    private Timestamp createdDate; // 등록한 date
+
+    private String title;
+
+    private String destination;
+
+    private double latitude;
+
+    private double longitude;
+
+    private Timestamp due; // 몇시까지?
+
+    private String detail;
+
+    private int reward;
+
+    private boolean isCash;
+
+    private Status status;
+
+    /**
+     *  request 받을 때 (save하려고 정보를 받을 때) 담당자 정보는 가져올 필요가 없다.
+     */
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -1,8 +1,8 @@
 package com.pknuErrand.appteam.service.errand;
 
 import com.pknuErrand.appteam.domain.errand.Errand;
-import com.pknuErrand.appteam.domain.errand.ErrandRequestDto;
-import com.pknuErrand.appteam.domain.errand.ErrandResponseDto;
+import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandRequestDto;
+import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandResponseDto;
 import com.pknuErrand.appteam.repository.errand.ErrandRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -41,6 +41,7 @@ public class ErrandService {
                 .reward(errandSaveRequestDto.getReward())
                 .isCash(errandSaveRequestDto.isCash())
                 .status(errandSaveRequestDto.getStatus())
+                .erranderNo(null)
                 .build();
         errandRepository.save(saveErrand);
         return new ErrandResponseDto(saveErrand);

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -1,8 +1,10 @@
 package com.pknuErrand.appteam.service.errand;
 
 import com.pknuErrand.appteam.domain.errand.Errand;
+import com.pknuErrand.appteam.domain.errand.ErrandBuilder;
 import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandRequestDto;
 import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandResponseDto;
+import com.pknuErrand.appteam.domain.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.repository.errand.ErrandRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -22,8 +24,24 @@ public class ErrandService {
     }
 
     @Transactional
-    public ErrandResponseDto createErrand(ErrandRequestDto errandRequestDto) {
-        Errand saveErrand = new Errand(errandRequestDto);
+    public ErrandResponseDto createErrand(ErrandSaveRequestDto errandSaveRequestDto) {
+        /**
+         *    Member orderMember = memberService.findMemberById(errandSaveRequestDto.getOrderNo());
+         *    member service 추가되면 수정 필요
+         */
+        Errand saveErrand = new ErrandBuilder()
+                .orderNo(errandSaveRequestDto.getOrderNo())
+                .createdDate(errandSaveRequestDto.getCreatedDate())
+                .title(errandSaveRequestDto.getTitle())
+                .destination(errandSaveRequestDto.getDestination())
+                .longitude(errandSaveRequestDto.getLongitude())
+                .longitude(errandSaveRequestDto.getLongitude())
+                .due(errandSaveRequestDto.getDue())
+                .detail(errandSaveRequestDto.getDetail())
+                .reward(errandSaveRequestDto.getReward())
+                .isCash(errandSaveRequestDto.isCash())
+                .status(errandSaveRequestDto.getStatus())
+                .build();
         errandRepository.save(saveErrand);
         return new ErrandResponseDto(saveErrand);
     }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #18 

### 📝 주요 작업 내용

> Errand 등록시 받아오는 데이터 dto를 saveRequestDto 로 변경하였음.

  order member의 정보를 받아올 때 기존 Memer member 가 아니라 Long meberPk 형태로 데이터를 받아옴.
이에 따라 불필요한 member 데이터를 받아올 필요 없음. 따라서 entity에 저장할때는 memberPk로 부터 member를 찾아서 저장함. 하지만 현재 member service 개발이 덜 된 상태라 차후 수정 필요함.

 saveRequestDto 에서는 errander의 정보를 필요로 하지 않음. errand를 저장할 때는 errander가 반드시 없기 때문에 client 에서 null data를 넘겨받는거보단 처음부터 안받고 server에서 database에 null 로 저장하는것이 더 타당함.

