### PR TITLE
Feat: Errand 하나 불러오기에 필요한 정보 수정

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -1,8 +1,9 @@
 package com.pknuErrand.appteam.controller.errand;
 
 
-import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandListResponseDto;
+import com.pknuErrand.appteam.domain.errand.getDto.ErrandListResponseDto;
 import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandResponseDto;
+import com.pknuErrand.appteam.domain.errand.getDto.ErrandDetailResponseDto;
 import com.pknuErrand.appteam.domain.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.service.errand.ErrandService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,7 +45,7 @@ public class ErrandController {
 
     @Operation(summary = "요청서 하나 불러오기" , description = "요청서의 PK (id) 를 통해 불러오기")
     @GetMapping("/{id}")  
-    public ResponseEntity<ErrandResponseDto> getOneErrand(@PathVariable Long id) {
+    public ResponseEntity<ErrandDetailResponseDto> getOneErrand(@PathVariable Long id) {
         return ResponseEntity.ok()
                 .body(errandService.findErrandById(id));
     } 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandDetailResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandDetailResponseDto.java
@@ -1,19 +1,16 @@
 package com.pknuErrand.appteam.domain.errand.getDto;
 
-import com.pknuErrand.appteam.domain.errand.Errand;
 import com.pknuErrand.appteam.domain.errand.Status;
 import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.domain.member.MemberErrandDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
-public class ErrandListResponseDto { // from Entity
+public class ErrandDetailResponseDto {
     private MemberErrandDto order; // 심부름 시킨사람
 
     private Timestamp createdDate; // 등록한 date
@@ -22,8 +19,17 @@ public class ErrandListResponseDto { // from Entity
 
     private String destination; // 도착지
 
+    private double latitude; // 위도
+
+    private double longitude; // 경도
+
+    private Timestamp due; // 몇시까지?
+
+    private String detail; // 상세 내용
+
     private int reward; // 보수금액
 
-    private Status status; // 상태
+    private boolean isCash; // 현금 계좌이체 선택
 
+    private Status status; // 상태
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -2,9 +2,10 @@ package com.pknuErrand.appteam.service.errand;
 
 import com.pknuErrand.appteam.domain.errand.Errand;
 import com.pknuErrand.appteam.domain.errand.ErrandBuilder;
-import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandListResponseDto;
+import com.pknuErrand.appteam.domain.errand.getDto.ErrandListResponseDto;
 import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandRequestDto;
 import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandResponseDto;
+import com.pknuErrand.appteam.domain.errand.getDto.ErrandDetailResponseDto;
 import com.pknuErrand.appteam.domain.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.domain.member.MemberErrandDto;
@@ -61,10 +62,23 @@ public class ErrandService {
                     memberErrandDto, errand.getCreatedDate(), errand.getTitle(),
                     errand.getDestination(), errand.getReward(), errand.getStatus()
             );
-            errandListResponseDtoList.add(ErrandListResponseDto);
+            errandListResponseDtoList.add(errandListResponseDto);
         }
         return errandListResponseDtoList;
     }
+
+    @Transactional
+    public ErrandDetailResponseDto findErrandById(long id) {
+        Errand errand = errandRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+        MemberErrandDto memberErrandDto = buildMemberErrandDto(errand.getOrderNo());
+        ErrandDetailResponseDto errandDetailResponseDto = new ErrandDetailResponseDto(
+                memberErrandDto, errand.getCreatedDate(), errand.getTitle(), errand.getDestination(),
+                errand.getLatitude(), errand.getLongitude(), errand.getDue(), errand.getDetail(),
+                errand.getReward(), errand.isCash(), errand.getStatus()
+        );
+        return errandDetailResponseDto;
+    }
+
     @Transactional
     /**
      *    member domain 추가되면 확인 필요
@@ -76,9 +90,5 @@ public class ErrandService {
         return new MemberErrandDto(memberNo, nickname, score);
     }
 
-    @Transactional
-    public ErrandResponseDto findErrandById(long id) {
-        Errand errand = errandRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
-        return new ErrandResponseDto(errand);
-    }
+
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #32 

### 📝 주요 작업 내용

> ErrandDetailResponseDto 를 추가하여 errand 하나 불러오기 시에 해당 정보를 response 하도록 변경
  ErrandDetailResponseDto에는 errander 정보는 뺐고 order 정보는 MemberErrandDto 사용
  MemberErrandDto는 

     private long errandNo;

    private String nickname;

    private double score;
 해당 정보를 가지고 있으며, ErrandServie 내에 buildMemberErrandDto 메서드를 통해 쉽게 생성 가능하다.

### 🖼️ 스크린샷 (선택)
![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/8442cae0-c510-4242-81d2-d3220d7477f2)

![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/6d701419-0676-432d-813d-7041ad683f94)

![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/d6afbb1e-b8e4-4bff-9729-e6b3d243c997)

