### PR TITLE
 [FEAT] 심부름 요청 수락 시 심부름 상태 변경 및 errander 정보 update 기능

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -48,5 +48,12 @@ public class ErrandController {
     public ResponseEntity<ErrandDetailResponseDto> getOneErrand(@PathVariable Long id) {
         return ResponseEntity.ok()
                 .body(errandService.findErrandById(id));
-    } 
+    }
+
+    @Operation(summary = "요청서 수락하기", description = "요청서 수락요청을 통해 errand status 변경하기")
+    @GetMapping("/{id}/accept")
+    public ResponseEntity<ErrandDetailResponseDto> acceptErrand(@PathVariable Long id) {
+        return ResponseEntity.ok()
+                .body(errandService.acceptErrand(id));
+    }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
@@ -11,7 +11,6 @@ import java.sql.Timestamp;
 
 @Getter
 @NoArgsConstructor
-@RequiredArgsConstructor
 @Entity(name = "errand")
 public class Errand {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -59,4 +58,24 @@ public class Errand {
     @JoinColumn
     private Member erranderNo; // 심부름꾼
 
+    public void changeErrandStatusAndSetErrander(Status status, Member errander) {
+        this.status = status;
+        erranderNo = errander;
+    }
+    public Errand(Member orderNo, Timestamp createdDate, String title, String destination,
+                  double latitude, double longitude, Timestamp due, String detail,
+                  int reward, boolean isCash, Status status, Member erranderNo) {
+        this.orderNo = orderNo;
+        this.createdDate = createdDate;
+        this.title = title;
+        this.destination = destination;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.due = due;
+        this.detail = detail;
+        this.reward = reward;
+        this.isCash = isCash;
+        this.status = status;
+        this.erranderNo = erranderNo;
+    }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #34 

### 📝 주요 작업 내용

1. 컨트롤러에 acceptErrand 메소드 추가
- 수정 기능인데 PUT, PATCH 대신 GET 메소드를 사용하는 이유는 상태를 변경할 값이 정해져있고, errander 정보는 인가된 사용자 정보를 http header에서 가져올 수 있기 때문에 request 받을 데이터가 errand id 밖에 없기 때문이다. 따라서 body로 받는것보다 쿼리파라미터로 id를 받아오는것이 알맞다고 판단함.

2. 서비스에 acceptErrand 메소드 추가
- id를 파라미터로 받아 errand를 불러오고 changeErrandStatusAndSetErrander 메서드를 통해 errand status와 errander 정보를 update함

3. 서비스에 changeErrandStatusAndSetErrander 메소드 추가
- 실질적으로 entity에 데이터를 update하는 메소드. 메소드를 분리한 이유는 
첫번째로 프론트에 변경된 게시물 상세 정보를 바로 넘겨주기 위해서이다. transactional 로 관리되는 서비스이기 때문에 한 메소드로 처리하면 해당 트랜잭션이 끝나 커밋되기 전에 변경사항이 저장되지 않아서 변경 전의 데이터가 사용자에게 노출될 수 있다. 하지만 트랜잭션을 분리하면 jpa가 db에 flush한 이후 변경된 errand를 불러올 수 있다.
두번째로 changeErrandStatusAndSetErrander 를 재사용하기 위해서이다. acceptErrand 메소드는 errand를 수락했을 때만 사용할 수 있는 메소드이지만, 메소드를 분리함으로써 errand를 수락취소하는 기능이 추가됐을 때 재사용 가능하다.

### 🖼️ 스크린샷 (선택)


![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/fa7fc2bd-73fb-4369-88d0-547c36e63c05)

![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/1254279f-1bab-4b0d-979b-18c9ce66981f)


