### PR TITLE
[REFACTOR] errand 관련 코드 리팩터링

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandDetailResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandDetailResponseDto.java
@@ -4,12 +4,14 @@ import com.pknuErrand.appteam.domain.errand.Status;
 import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.domain.member.MemberErrandDto;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.sql.Timestamp;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class ErrandDetailResponseDto {
     private MemberErrandDto order; // 심부름 시킨사람
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandListResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandListResponseDto.java
@@ -5,6 +5,7 @@ import com.pknuErrand.appteam.domain.errand.Status;
 import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.domain.member.MemberErrandDto;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,6 +14,7 @@ import java.sql.Timestamp;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class ErrandListResponseDto { // from Entity
     private MemberErrandDto order; // 심부름 시킨사람
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -52,30 +52,46 @@ public class ErrandService {
         return new ErrandResponseDto(saveErrand);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ErrandListResponseDto> findAllErrand() {
         List<Errand> errandList = errandRepository.findAll();
         List<ErrandListResponseDto> errandListResponseDtoList = new ArrayList<>();
         for(Errand errand : errandList) {
             MemberErrandDto memberErrandDto = buildMemberErrandDto(errand.getErranderNo());
-            ErrandListResponseDto errandListResponseDto = new ErrandListResponseDto(
-                    memberErrandDto, errand.getCreatedDate(), errand.getTitle(),
-                    errand.getDestination(), errand.getReward(), errand.getStatus()
-            );
+
+            ErrandListResponseDto errandListResponseDto = ErrandListResponseDto.builder()
+                    .order(memberErrandDto)
+                    .createdDate(errand.getCreatedDate())
+                    .title(errand.getTitle())
+                    .destination(errand.getDestination())
+                    .reward(errand.getReward())
+                    .status(errand.getStatus())
+                    .build();
+
             errandListResponseDtoList.add(errandListResponseDto);
         }
         return errandListResponseDtoList;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ErrandDetailResponseDto findErrandById(long id) {
         Errand errand = errandRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 심부름 없음"));
         MemberErrandDto memberErrandDto = buildMemberErrandDto(errand.getOrderNo());
-        ErrandDetailResponseDto errandDetailResponseDto = new ErrandDetailResponseDto(
-                memberErrandDto, errand.getCreatedDate(), errand.getTitle(), errand.getDestination(),
-                errand.getLatitude(), errand.getLongitude(), errand.getDue(), errand.getDetail(),
-                errand.getReward(), errand.isCash(), errand.getStatus()
-        );
+
+        ErrandDetailResponseDto errandDetailResponseDto = ErrandDetailResponseDto.builder()
+                .order(memberErrandDto)
+                .createdDate(errand.getCreatedDate())
+                .title(errand.getTitle())
+                .destination(errand.getDestination())
+                .latitude(errand.getLatitude())
+                .longitude(errand.getLongitude())
+                .due(errand.getDue())
+                .detail(errand.getDetail())
+                .reward(errand.getReward())
+                .isCash(errand.isCash())
+                .status(errand.getStatus())
+                .build();
+
         return errandDetailResponseDto;
     }
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #38 

### 📝 주요 작업 내용

> 읽기 전용 메소드인 findAllErrand(), findErrandById(long id)에 @Transactional(readOnly = true)를 추가하였음.
   jpa 영속성 컨텍스트에서 dirty checking을 하지 않아 성능 향상 + 가독성

> lombok의 @builder을 DTO에 사용하여 빌더패턴을 통해 가독성 향상시킴

![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/ee1f8c97-5c58-47af-9979-191331129611)
 
