### PR TITLE
feature/40-errand-하나-불러올-때-isMyErrand-필드-추가

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
@@ -48,7 +48,7 @@ public class Errand {
     private int reward;
 
     @Column
-    private boolean isCash;
+    private Boolean isCash;
 
     @Column
     @Enumerated(EnumType.STRING)
@@ -64,7 +64,7 @@ public class Errand {
     }
     public Errand(Member orderNo, Timestamp createdDate, String title, String destination,
                   double latitude, double longitude, Timestamp due, String detail,
-                  int reward, boolean isCash, Status status, Member erranderNo) {
+                  int reward, Boolean isCash, Status status, Member erranderNo) {
         this.orderNo = orderNo;
         this.createdDate = createdDate;
         this.title = title;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandRequestDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandRequestDto.java
@@ -32,7 +32,7 @@ public class ErrandRequestDto { // to Entity
 
     private int reward;
 
-    private boolean isCash;
+    private Boolean isCash;
 
     private Status status;
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandResponseDto.java
@@ -31,7 +31,7 @@ public class ErrandResponseDto { // from Entity
 
     private int reward; // 보수금액
 
-    private boolean isCash; // 현금 계좌이체 선택
+    private Boolean isCash; // 현금 계좌이체 선택
 
     private Status status; // 상태
 
@@ -47,7 +47,7 @@ public class ErrandResponseDto { // from Entity
         this.due = errand.getDue();
         this.detail = errand.getDetail();
         this.reward = errand.getReward();
-        this.isCash = errand.isCash();
+        this.isCash = errand.getIsCash();
         this.status = errand.getStatus();
         this.erranderNo = errand.getErranderNo();
     }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandDetailResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandDetailResponseDto.java
@@ -31,7 +31,9 @@ public class ErrandDetailResponseDto {
 
     private int reward; // 보수금액
 
-    private boolean isCash; // 현금 계좌이체 선택
+    private Boolean isCash; // 현금 계좌이체 선택
 
     private Status status; // 상태
+
+    private Boolean isMyErrand; // 본인 게시물인가?
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -88,8 +88,9 @@ public class ErrandService {
                 .due(errand.getDue())
                 .detail(errand.getDetail())
                 .reward(errand.getReward())
-                .isCash(errand.isCash())
+                .isCash(errand.getIsCash())
                 .status(errand.getStatus())
+                .isMyErrand(memberErrandDto.getErrandNo() == 5) /**  인가된 사용자 정보와 비교  **/
                 .build();
 
         return errandDetailResponseDto;


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #40 

### 📝 주요 작업 내용

> ErrandDetailResponseDto에 isMyErrand 추가
   프론트에서 수정삭제 버튼을 활성화시킬 글쓴이인지, 수락버튼 활성화시킬 사람일지 구분할 수 있도록

> boolean -> Boolean 으로 전부 변경
   json 데이터 타입으로 응답할 때 boolean으로 리턴하면 변수명에서 is가 빠지고 true/false가 아닌 1/0으로 return 되는 문제가 발생. 따라서 wrapper class인 Boolean으로 변경
https://velog.io/@hellojihyoung/Error-Response-JSON%EC%97%90%EC%84%9C-Boolean%EC%9D%98-is%EA%B0%80-%EC%83%9D%EB%9E%B5%EB%90%98%EB%8A%94-%EB%AC%B8%EC%A0%9C

