### PR TITLE
feature/45-errand-수정-기능-추가

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -56,4 +56,11 @@ public class ErrandController {
         return ResponseEntity.ok()
                 .body(errandService.acceptErrand(id));
     }
+
+    @Operation(summary = "요청서 수정하기", description = "요청서 수정을 통해 errand field 변경하기")
+    @PutMapping("/{id}")
+    public ResponseEntity<ErrandDetailResponseDto> updateErrand(@PathVariable Long id, @RequestBody ErrandSaveRequestDto errandSaveRequestDto) {
+        return ResponseEntity.ok()
+                .body(errandService.updateErrand(id, errandSaveRequestDto));
+    }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
@@ -1,8 +1,10 @@
 package com.pknuErrand.appteam.domain.errand;
 
 
+import com.pknuErrand.appteam.domain.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.domain.member.Member;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -61,6 +63,21 @@ public class Errand {
     public void changeErrandStatusAndSetErrander(Status status, Member errander) {
         this.status = status;
         erranderNo = errander;
+    }
+
+    public void updateErrand(Timestamp createdDate, String title, String destination,
+                             double latitude, double longitude, Timestamp due, String detail,
+                             int reward, Boolean isCash, Status status) {
+        this.createdDate = createdDate;
+        this.title = title;
+        this.destination = destination;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.due = due;
+        this.detail = detail;
+        this.reward = reward;
+        this.isCash = isCash;
+        this.status = status;
     }
     public Errand(Member orderNo, Timestamp createdDate, String title, String destination,
                   double latitude, double longitude, Timestamp due, String detail,

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -101,7 +101,6 @@ public class ErrandService {
         Errand errand = errandRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 심부름 없음"));
         Member errander = null;  /** 인가된 사용자 정보 불러오기 **/
 
-        /** 실제 entity에 업데이트 하는 부분의 트랜잭션을 분리하여 변경 내용이 flush 되어 바로 변경된 errand정보를 response 할 수 있도록 한다. **/
         changeErrandStatusAndSetErrander(errand, Status.IN_PROGRESS, errander);
         return findErrandById(id);
     }
@@ -121,5 +120,26 @@ public class ErrandService {
         return new MemberErrandDto(memberNo, nickname, score);
     }
 
-
+    @Transactional
+    public ErrandDetailResponseDto updateErrand(Long id, ErrandSaveRequestDto errandSaveRequestDto) {
+        /**
+         *    security context holder에서 인가된 사용자의 id를 받아오고 findById를 통해 member 객체 불러올 예정
+         */
+        Member orderMember = null; /** 인가된 사용자 정보 불러오기 **/
+        Errand errand = errandRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 심부름 없음"));
+        if(!errand.getOrderNo().equals(orderMember)) {
+            throw new IllegalArgumentException("게시물 수정 권한 없음"); /** 커스텀 Exception 생성 필요 **/
+        }
+        errand.updateErrand(errandSaveRequestDto.getCreatedDate(),
+                errandSaveRequestDto.getTitle(),
+                errandSaveRequestDto.getDestination(),
+                errandSaveRequestDto.getLatitude(),
+                errandSaveRequestDto.getLongitude(),
+                errandSaveRequestDto.getDue(),
+                errandSaveRequestDto.getDetail(),
+                errandSaveRequestDto.getReward(),
+                errandSaveRequestDto.isCash(),
+                errandSaveRequestDto.getStatus());
+        return findErrandById(id);
+    }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #45 

### 📝 주요 작업 내용

- errand update 컨트롤러 추가
   ErrandSaveRequestDto를 사용하였음. 해당 dto의 필드값을 한두개말곤 다 사용가능해서 재활용했음.

- Errand entity 클래스에 updateErrand 메소드 추가 (필요한 파라미터는 save와 조금 다르다)

- 서비스에 updateErrand 메소드 추가

