### PR TITLE
Feature/51 errand 정렬 및 카테고리 분류 후 페이지네이션 기능

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -4,6 +4,7 @@ package com.pknuErrand.appteam.controller.errand;
 import com.pknuErrand.appteam.domain.errand.getDto.ErrandListResponseDto;
 import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandResponseDto;
 import com.pknuErrand.appteam.domain.errand.getDto.ErrandDetailResponseDto;
+import com.pknuErrand.appteam.domain.errand.getDto.ErrandPaginationRequest;
 import com.pknuErrand.appteam.domain.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.service.errand.ErrandService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,7 +37,7 @@ public class ErrandController {
     }
 
     @Operation(summary = "요청서 전부 불러오기" , description = "심부름 요청서 전부 불러오기")
-    @GetMapping
+    @GetMapping("/all")
     public ResponseEntity<List<ErrandListResponseDto>> getAllErrand() {
         List<ErrandListResponseDto> errandListResponseDto = errandService.findAllErrand();
         return ResponseEntity.ok()
@@ -48,6 +49,13 @@ public class ErrandController {
     public ResponseEntity<ErrandDetailResponseDto> getOneErrand(@PathVariable Long id) {
         return ResponseEntity.ok()
                 .body(errandService.findErrandById(id));
+    }
+
+    @Operation(summary = "메인화면 요청서 불러오기 (무한스크롤)", description = "정렬방법, 커서위치, 게시물 갯수를 입력받아 요청서를 불러온다")
+    @GetMapping
+    public ResponseEntity<List<ErrandListResponseDto>> getPaginationErrand(ErrandPaginationRequest pageInfo) {
+        return ResponseEntity.ok()
+                .body(errandService.findPaginationErrand(pageInfo));
     }
 
     @Operation(summary = "요청서 수락하기", description = "요청서 수락요청을 통해 errand status 변경하기")

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -4,7 +4,7 @@ package com.pknuErrand.appteam.controller.errand;
 import com.pknuErrand.appteam.domain.errand.getDto.ErrandListResponseDto;
 import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandResponseDto;
 import com.pknuErrand.appteam.domain.errand.getDto.ErrandDetailResponseDto;
-import com.pknuErrand.appteam.domain.errand.getDto.ErrandPaginationRequest;
+import com.pknuErrand.appteam.domain.errand.getDto.ErrandPaginationRequestVo;
 import com.pknuErrand.appteam.domain.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.service.errand.ErrandService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,7 +53,7 @@ public class ErrandController {
 
     @Operation(summary = "메인화면 요청서 불러오기 (무한스크롤)", description = "정렬방법, 커서위치, 게시물 갯수를 입력받아 요청서를 불러온다")
     @GetMapping
-    public ResponseEntity<List<ErrandListResponseDto>> getPaginationErrand(ErrandPaginationRequest pageInfo) {
+    public ResponseEntity<List<ErrandListResponseDto>> getPaginationErrand(ErrandPaginationRequestVo pageInfo) {
         return ResponseEntity.ok()
                 .body(errandService.findPaginationErrand(pageInfo));
     }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
@@ -13,7 +13,7 @@ import java.sql.Timestamp;
 
 @Getter
 @NoArgsConstructor
-@Entity(name = "errand")
+@Entity(name = "Errand")
 public class Errand {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
@@ -21,12 +21,12 @@ public class Errand {
     private long errandNo;
 
 
-    @ManyToOne // 이 어노테이션 걸면 자동으로 getter를 해주나.. ?
+    @ManyToOne
     @JoinColumn
     private Member orderNo; // 심부름 시킨사람의 pk
 
     @Column
-    private Timestamp createdDate; // 등록한 date
+    private String createdDate; // 등록한 date
 
     @Column
     private String title;
@@ -65,7 +65,7 @@ public class Errand {
         erranderNo = errander;
     }
 
-    public void updateErrand(Timestamp createdDate, String title, String destination,
+    public void updateErrand(String createdDate, String title, String destination,
                              double latitude, double longitude, Timestamp due, String detail,
                              int reward, Boolean isCash) {
         this.createdDate = createdDate;
@@ -78,7 +78,7 @@ public class Errand {
         this.reward = reward;
         this.isCash = isCash;
     }
-    public Errand(Member orderNo, Timestamp createdDate, String title, String destination,
+    public Errand(Member orderNo, String createdDate, String title, String destination,
                   double latitude, double longitude, Timestamp due, String detail,
                   int reward, Boolean isCash, Status status, Member erranderNo) {
         this.orderNo = orderNo;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/ErrandBuilder.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/ErrandBuilder.java
@@ -8,7 +8,7 @@ import java.sql.Timestamp;
 public class ErrandBuilder {
 
     private Member orderNo;
-    private Timestamp createdDate;
+    private String createdDate;
     private String title;
     private String destination;
     private double latitude;
@@ -25,7 +25,7 @@ public class ErrandBuilder {
         return this;
     }
 
-    public ErrandBuilder createdDate(Timestamp createdDate) {
+    public ErrandBuilder createdDate(String createdDate) {
         this.createdDate = createdDate;
         return this;
     }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Sort.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Sort.java
@@ -1,0 +1,5 @@
+package com.pknuErrand.appteam.domain.errand;
+
+public enum Sort {
+    LATEST, DISTANCE, REWARD;
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandRequestDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandRequestDto.java
@@ -16,7 +16,7 @@ public class ErrandRequestDto { // to Entity
 
     private Member orderNo; // 심부름 시킨사람
 
-    private Timestamp createdDate; // 등록한 date
+    private String createdDate; // 등록한 date
 
     private String title;
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/defaultDto/ErrandResponseDto.java
@@ -15,7 +15,7 @@ import java.sql.Timestamp;
 public class ErrandResponseDto { // from Entity
     private Member orderNo; // 심부름 시킨사람
 
-    private Timestamp createdDate; // 등록한 date
+    private String createdDate; // 등록한 date
 
     private String title; // 심부름 제목
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandDetailResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandDetailResponseDto.java
@@ -15,7 +15,7 @@ import java.sql.Timestamp;
 public class ErrandDetailResponseDto {
     private MemberErrandDto order; // 심부름 시킨사람
 
-    private Timestamp createdDate; // 등록한 date
+    private String createdDate; // 등록한 date
 
     private String title; // 심부름 제목
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandListResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandListResponseDto.java
@@ -18,7 +18,7 @@ import java.sql.Timestamp;
 public class ErrandListResponseDto { // from Entity
     private MemberErrandDto order; // 심부름 시킨사람
 
-    private Timestamp createdDate; // 등록한 date
+    private String createdDate; // 등록한 date
 
     private String title; // 심부름 제목
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandPaginationRequest.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandPaginationRequest.java
@@ -1,0 +1,16 @@
+package com.pknuErrand.appteam.domain.errand.getDto;
+
+import com.pknuErrand.appteam.domain.errand.Sort;
+import com.pknuErrand.appteam.domain.errand.Status;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ErrandPaginationRequest {
+    private Long pk;
+    private String cursor;
+    private int limit;
+    private Status status;
+    private Sort sort;
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandPaginationRequestVo.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandPaginationRequestVo.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public class ErrandPaginationRequest {
+public class ErrandPaginationRequestVo {
     private Long pk;
     private String cursor;
     private int limit;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/saveDto/ErrandSaveRequestDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/saveDto/ErrandSaveRequestDto.java
@@ -18,7 +18,7 @@ public class ErrandSaveRequestDto { // to Entity
      *  게시글 등록하는 member의 정보는 jwt에서 추출
      */
 
-    private Timestamp createdDate; // 등록한 date
+    private String createdDate; // 등록한 date
 
     private String title;
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandRepository.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandRepository.java
@@ -1,7 +1,38 @@
 package com.pknuErrand.appteam.repository.errand;
-
 import com.pknuErrand.appteam.domain.errand.Errand;
+import com.pknuErrand.appteam.domain.errand.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ErrandRepository extends JpaRepository<Errand, Long> {
+
+    @Query(value = "SELECT * " +
+            "FROM errand " +
+            "WHERE (created_date = :cursor AND errand_no > :pk) OR created_date > :cursor " +
+            "ORDER BY created_date ASC, errand_no DESC LIMIT :limit", nativeQuery = true)
+    List<Errand> findErrandByLatest(@Param("pk") Long pk, @Param("cursor") String cursor, @Param("limit") int limit);
+
+    @Query(value = "SELECT * " +
+            "FROM errand " +
+            "WHERE (status = :status) AND ((created_date = :cursor AND errand_no > :pk) OR created_date > :cursor) " +
+            "ORDER BY created_date ASC, errand_no DESC LIMIT :limit", nativeQuery = true)
+    List<Errand> findErrandByStatusAndLatest(@Param("pk") Long pk, @Param("cursor") String cursor, @Param("limit") int limit,
+                                             @Param("status") String status);
+
+    @Query(value = "SELECT * " +
+            "FROM errand " +
+            "WHERE (reward = :cursor AND errand_no > :pk) OR reward < :cursor " +
+            "ORDER BY reward DESC, errand_no DESC LIMIT :limit", nativeQuery = true)
+    List<Errand> findErrandByReward(@Param("pk") Long pk, @Param("cursor") int cursor, @Param("limit") int limit);
+
+    @Query(value = "SELECT * " +
+            "FROM errand " +
+            "WHERE (status = :status) AND ((reward = :cursor AND errand_no > :pk) OR reward < :cursor) " +
+            "ORDER BY reward DESC, errand_no DESC LIMIT :limit", nativeQuery = true)
+    List<Errand> findErrandByStatusAndReward(@Param("pk") Long pk, @Param("cursor") int cursor, @Param("limit") int limit,
+                                              @Param("status") String status);
+
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -7,7 +7,7 @@ import com.pknuErrand.appteam.domain.errand.Status;
 import com.pknuErrand.appteam.domain.errand.getDto.ErrandListResponseDto;
 import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandResponseDto;
 import com.pknuErrand.appteam.domain.errand.getDto.ErrandDetailResponseDto;
-import com.pknuErrand.appteam.domain.errand.getDto.ErrandPaginationRequest;
+import com.pknuErrand.appteam.domain.errand.getDto.ErrandPaginationRequestVo;
 import com.pknuErrand.appteam.domain.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.domain.member.MemberErrandDto;
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,7 +56,7 @@ public class ErrandService {
         return new ErrandResponseDto(saveErrand);
     }
     @Transactional(readOnly = true)
-    public List<ErrandListResponseDto> findPaginationErrand(ErrandPaginationRequest pageInfo) {
+    public List<ErrandListResponseDto> findPaginationErrand(ErrandPaginationRequestVo pageInfo) {
         if(pageInfo.getLimit() <= 0)
             throw new IllegalArgumentException("limit은 1보다 같거나 커야합니다.");
         List<Errand> errandList = null;


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #51 

### 📝 주요 작업 내용

1. 오프셋 기반 페이지네이션 vs 커서 기반 페이지네이션 -> 커서기반 페이지네이션 선택

2. 페이지네이션 정보를 입력받는 ErrandPaginationRequestVo 추가
   - errand pk /  마지막 errand의 커서 / limit (가져올 errand 수) / status 정보 (카테고리) / sort (정렬방식 enum 클래스)  
   
3. 페이지네이션 컨트롤러 생성, ErrandPaginationRequestVo를 파라미터로 받는다.

4. 서비스 레이어에 findPaginationErrand 메소드 추가
   - sort 방식에 따라 다른 repository 메소드를 호출한다. 받아온 List<Errand>를 List<ErrandListResponseDto>로 변환하여 return

5. 레포지토리에 조건에 맞는 errand를 불러오는 메소드 추가
   - findErrandByLatest : 페이징 조건에 맞는 errand를 최신순으로 받아옴
   - findErrandByStatusAndLatest : 페이징 조건에 맞는 errand 중 status를 분류하여 최신순으로 받아옴
   - findErrandByReward : 페이징 조건에 맞는 errand를 금액순으로 받아옴
   - findErrandByStatusAndReward : 페이징 조건에 맞는 errand 중 status를 분류하여 금액순으로 받아옴
   
   Q1. 조건을 변수로 받지않고 메소드를 분류한 이유?
   -> 조건이 많지 않고, 정렬기준 또한 많이 바뀌기 때문에 (ASC, DESC) 분류하는것이 타당하다고 생각함
   
   Q2. 최신순을 createdDate 기준으로 한 이유? 그냥 pk의 DESC순으로 하면 최신순이지 않은가?
   ->  이후 끌올 (게시글을 최신상태로 바꾸는) 기능을 생각했을 때, created Date값을 변경하는 것만으로도 기능을 만들 수 있음
        하지만 pk를 사용하여 정렬할 경우 새로운 pk를 배정해줘야함. 이 때 여러 문제가 발생할 수 있다고 판단.
        
   Q3. spring data jpa의 쿼리메소드도 아닌 jpql도 아닌 nativeQuery를 사용한 이유?
   -> 쿼리메소드로 메소드를 만들기에는 조건이 생각보다 많음. 또 Page 객체가 아닌 페이지 정보를 받아오는 커스텀 클래스인
       ErrandPaginationRequestVo를 사용하기 때문에 limit 등을 처리하기 위해서는 커서기반이 아닌 오프셋 기반으로 조회할 수
       밖에 없게됨. jpql의 경우 limit 메서드가 없어서 커서기반으로 처리 불가. 따라서 nativeQuery 사용

![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/ca8ae732-263a-4acd-a27a-16bb622a6b7d)


+ 거리순의 경우는 db의 데이터를 정렬하는 것만으로는 해결되지않고 사용자 위치정보가 필요하여 더욱 복잡한 쿼리를 만들어야함. 따라서 따로 분리해서 다음번에 진행하겠음 ^^