### PR TITLE
feature/69-인가된-사용자-정보-가져오는-기능-추가

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/config/SwaggerConfig.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.pknuErrand.appteam;
+package com.pknuErrand.appteam.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -6,9 +6,12 @@ import com.pknuErrand.appteam.domain.errand.defaultDto.ErrandResponseDto;
 import com.pknuErrand.appteam.domain.errand.getDto.ErrandDetailResponseDto;
 import com.pknuErrand.appteam.domain.errand.getDto.ErrandPaginationRequestVo;
 import com.pknuErrand.appteam.domain.errand.saveDto.ErrandSaveRequestDto;
+import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.service.errand.ErrandService;
+import com.pknuErrand.appteam.service.member.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,16 +19,19 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @Tag(name = "Errand", description = "Errand 관련 API")
 @Controller
 @RequestMapping("/errand")
 public class ErrandController {
 
     private final ErrandService errandService;
+    private final MemberService memberService;
 
     @Autowired
-    ErrandController(ErrandService errandService) {
+    ErrandController(ErrandService errandService, MemberService memberService) {
         this.errandService = errandService;
+        this.memberService = memberService;
     }
 
 
@@ -77,5 +83,14 @@ public class ErrandController {
     @DeleteMapping("/{id}")
     public void deleteErrand(@PathVariable Long id) {
         errandService.deleteErrand(id);
+    }
+
+    @GetMapping("/loginTest")
+    public void 로그인테스트() {
+        Member member = memberService.getLoginMember();
+        log.info("member id = {}", member.getId());
+        log.info("member name = {}", member.getName());
+        if(member == null)
+            log.warn("member is null");
     }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/jwt/JWTFilter.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/jwt/JWTFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -14,6 +15,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 public class JWTFilter extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
@@ -42,9 +44,11 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String token = authorization.split(" ")[1];
 
+        log.info("토큰시간 검증 이전");
+
         // 토큰 소멸 시간 검증
         if (jwtUtil.isExpired(token)) {
-
+            log.info("토큰시간 만료");
             System.out.println("token expired");
             filterChain.doFilter(request, response);
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/jwt/JWTUtil.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/jwt/JWTUtil.java
@@ -1,6 +1,7 @@
 package com.pknuErrand.appteam.jwt;
 
 import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +10,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
+@Slf4j
 @Component
 public class JWTUtil {
 
@@ -30,7 +32,9 @@ public class JWTUtil {
     }
 
     public Boolean isExpired(String token) {
-
+        Date expiredData = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration();
+        log.info("해당 토큰의 만료기간 = {}", expiredData);
+        log.info("현재 spring server 시간 = {}", new Date());
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/jwt/LoginFilter.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/jwt/LoginFilter.java
@@ -54,7 +54,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(username, role, 60*60*10L);
+        String token = jwtUtil.createJwt(username, role, 10000*60*60*10L);
 
         // RFC 7235 정의에 따른 인증 헤더 형태
         response.addHeader("Authorization", "Bearer " + token);

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/member/MemberService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/member/MemberService.java
@@ -4,6 +4,8 @@ import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.domain.member.MemberFormDto;
 import com.pknuErrand.appteam.repository.member.MemberRepository;
 import jakarta.transaction.Transactional;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -37,5 +39,16 @@ public class MemberService{
         String nickname = memberFormDto.getNickname();
 
         memberRepository.save(new Member(mail, department, name, id, bCryptPasswordEncoder.encode(pw), nickname, 0, "ROLE_ADMIN"));
+    }
+    public Member findMemberById(String id) {
+        Member member = memberRepository.findById(id);
+        return member;
+    }
+
+    public Member getLoginMember() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        UserDetails userDetails = (UserDetails)principal;
+        String username = userDetails.getUsername();
+        return findMemberById(username);
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #69 

### 📝 주요 작업 내용

1.  Member Service에 findMemberById(String id) 메소드 추가

2.  로그인 한 사용자 정보를 불러오는 getLoginMember() 메소드 추가

3. 로그인테스트() 컨트롤러를 만들어 테스트

  - postman의 header에 발급받은 Authorization 키를 넣고 테스트 컨트롤러로 요청을 보냈으나 예외 발생
  - 디버깅 결과 jwt 의 만료기간을 확인하는 로직 ( JWTUtil / isExpired() 메소드 ) 에서 필터링 되는것을 확인
  - 해당 메소드에 log를 찍어보니 토큰 만료기간이 굉장히 짧게 설정되어있는것을 확인
  
![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/902d4cff-93d2-4456-8a96-bffabfda1026)

![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/11999dda-7ac9-4937-8c81-24c845ab9e27)

  - LoginFilter의 토큰을 발급하는 로직에서 jwt.expiration 설정이 (60x60x10) 밀리초로 설정되어있는것을 확인
  - refresh 토큰 발급 기능이 아직 없으므로 jwt 만료기간을 더 늘렸음
  
 ![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/9fb104c1-a60a-4d27-8a6b-b9b0829cb71b)

 ![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/f3b5883a-235f-4cbf-9b11-9f0589175155)

  - 현재 토큰 만료기간 (10000x60x60x10)ms  -> 100시간
