### PR TITLE
feature/74 custom exception 예외 관리

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/AppteamApplication.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/AppteamApplication.java
@@ -9,6 +9,7 @@ public class AppteamApplication {
 	public static void main(String[] args) {
 
 		SpringApplication.run(AppteamApplication.class, args);
+
 	}
 
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -7,6 +7,8 @@ import com.pknuErrand.appteam.domain.errand.getDto.ErrandDetailResponseDto;
 import com.pknuErrand.appteam.domain.errand.getDto.ErrandPaginationRequestVo;
 import com.pknuErrand.appteam.domain.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.domain.member.Member;
+import com.pknuErrand.appteam.exception.CustomException;
+import com.pknuErrand.appteam.exception.ErrorCode;
 import com.pknuErrand.appteam.service.errand.ErrandService;
 import com.pknuErrand.appteam.service.member.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -93,4 +95,5 @@ public class ErrandController {
         if(member == null)
             log.warn("member is null");
     }
+
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomException.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomException.java
@@ -16,7 +16,7 @@ public class CustomException extends RuntimeException{
         this.message = errorCode.getMessage();
     }
 
-    CustomException(ErrorCode errorCode, String message) {
+    public CustomException(ErrorCode errorCode, String message) {
         super(errorCode.getMessage());
         this.name = errorCode.name();
         this.httpStatus = errorCode.getHttpStatus();

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomException.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomException.java
@@ -9,7 +9,7 @@ public class CustomException extends RuntimeException{
     private final String name;
     private final HttpStatus httpStatus;
     private final String message;
-    CustomException(ErrorCode errorCode) {
+    public CustomException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.name = errorCode.name();
         this.httpStatus = errorCode.getHttpStatus();

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomException.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomException.java
@@ -1,0 +1,25 @@
+package com.pknuErrand.appteam.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException{
+
+    private final String name;
+    private final HttpStatus httpStatus;
+    private final String message;
+    CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.name = errorCode.name();
+        this.httpStatus = errorCode.getHttpStatus();
+        this.message = errorCode.getMessage();
+    }
+
+    CustomException(ErrorCode errorCode, String message) {
+        super(errorCode.getMessage());
+        this.name = errorCode.name();
+        this.httpStatus = errorCode.getHttpStatus();
+        this.message = message;
+    }
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomExceptionHandler.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.pknuErrand.appteam.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ExceptionResponseDto> exceptionHandler(CustomException e) {
+
+        log.warn("{} \n {} {}", e.getName(), e.getHttpStatus(), e.getMessage());
+
+        ExceptionResponseDto exceptionResponseDto = ExceptionResponseDto.builder()
+                .name(e.getName())
+                .httpStatus(e.getHttpStatus())
+                .message(e.getMessage())
+                .build();
+        return exceptionResponseDto.buildEntity();
+    }
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomExceptionHandler.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.pknuErrand.appteam.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,15 +11,30 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class CustomExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ExceptionResponseDto> exceptionHandler(CustomException e) {
+    public ResponseEntity<ExceptionResponseDto> customExceptionHandler(CustomException e) {
 
-        log.warn("{} \n {} {}", e.getName(), e.getHttpStatus(), e.getMessage());
+        log.error("{} / {} / {}\n\n", e.getName(), e.getHttpStatus(), e.getMessage());
 
-        ExceptionResponseDto exceptionResponseDto = ExceptionResponseDto.builder()
-                .name(e.getName())
-                .httpStatus(e.getHttpStatus())
-                .message(e.getMessage())
-                .build();
-        return exceptionResponseDto.buildEntity();
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ExceptionResponseDto.builder()
+                        .name(e.getName())
+                        .httpStatus(e.getHttpStatus())
+                        .message(e.getMessage())
+                        .build());
     }
+
+    @ExceptionHandler
+    public ResponseEntity<?> AnotherExceptionHandler(Exception e) {
+
+        log.error("Exception / {}", e.getMessage());
+        e.printStackTrace();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ExceptionResponseDto.builder()
+                        .name(e.toString().split(":")[0])
+                        .httpStatus(HttpStatus.BAD_REQUEST)
+                        .message(e.getMessage())
+                        .build());
+    }
+
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ErrorCode.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ErrorCode.java
@@ -7,8 +7,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+
+
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    ERRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "심부름을 찾을 수 없습니다.");
+    ERRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "심부름을 찾을 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    RESTRICT_CONTENT_ACCESS(HttpStatus.BAD_REQUEST, "변경할 수 업습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ErrorCode.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.pknuErrand.appteam.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    ERRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "심부름을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ExceptionResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ExceptionResponseDto.java
@@ -1,17 +1,15 @@
 package com.pknuErrand.appteam.exception;
 
 import lombok.Builder;
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+@Getter
 @Builder
 public class ExceptionResponseDto {
     private final String name;
     private final HttpStatus httpStatus;
     private final String message;
 
-    public ResponseEntity<ExceptionResponseDto> buildEntity() {
-        return ResponseEntity.status(httpStatus)
-                .body(this);
-    }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ExceptionResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ExceptionResponseDto.java
@@ -1,0 +1,17 @@
+package com.pknuErrand.appteam.exception;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Builder
+public class ExceptionResponseDto {
+    private final String name;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public ResponseEntity<ExceptionResponseDto> buildEntity() {
+        return ResponseEntity.status(httpStatus)
+                .body(this);
+    }
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/jwt/JWTFilter.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/jwt/JWTFilter.java
@@ -2,6 +2,8 @@ package com.pknuErrand.appteam.jwt;
 
 import com.pknuErrand.appteam.domain.member.MemberUserDetails;
 import com.pknuErrand.appteam.domain.member.MemberUserDetailsDto;
+import com.pknuErrand.appteam.exception.CustomException;
+import com.pknuErrand.appteam.exception.ErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,8 +40,6 @@ public class JWTFilter extends OncePerRequestFilter {
             System.out.println("token null");
             filterChain.doFilter(request, response);
 
-            // 조건이 해당되면 메소드 종료
-            return;
         }
 
         String token = authorization.split(" ")[1];

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/jwt/LoginFilter.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/jwt/LoginFilter.java
@@ -1,9 +1,12 @@
 package com.pknuErrand.appteam.jwt;
 
 import com.pknuErrand.appteam.domain.member.MemberUserDetails;
+import com.pknuErrand.appteam.exception.CustomException;
+import com.pknuErrand.appteam.exception.ErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -14,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import java.util.Collection;
 import java.util.Iterator;
 
+@Slf4j
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
@@ -34,7 +38,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         // Spring Security 에서 username과 password를 검증하기 위해서는 token에 담아야 함
         UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
-        
+
         // token에 담은 검증을 위한 AuthenticationManager로 전달
         return authenticationManager.authenticate(authToken);
     }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #74 

### 📝 주요 작업 내용

- ErrorCode enum 생성 (httpstatus와 기본 message를 필드로 가짐)

- ErrorCode를 생성자로 가지는 CustomException 생성 (extends RuntimeException)

- CustomExceptionHandler를 통해 전역 예외 관리
-> 예외 로그 생성 및 에러 상태를 ResponseEntity<>를 통해 클라이언트에 전달

### 💬 리뷰 요구사항

> 커스텀으로 예외처리할 일 있을 때 이거쓰면 됩니당
