### PR TITLE
feature/83 feat 회원가입시 이메일 인증 기능 추가

### DIFF
--- a/server/appteam/build.gradle
+++ b/server/appteam/build.gradle
@@ -16,6 +16,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation('org.projectlombok:lombok')
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/AppteamApplication.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/AppteamApplication.java
@@ -12,7 +12,7 @@ public class AppteamApplication {
 
 		SpringApplication.run(AppteamApplication.class, args);
 
-		System.out.println("develop - BE Branch");
+		//System.out.println("develop - BE Branch");
 
 	}
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/config/SecurityConfig.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/app1-api.html","/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**").permitAll() // swagger 경로 인가
-                        .requestMatchers("/login", "/", "/join").permitAll() // 로그인, 회원가입 페이지
+                        .requestMatchers("/login", "/", "/join", "/mail/**").permitAll() // 로그인, 회원가입 페이지
                         .anyRequest().authenticated());
 
         http

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/MailController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/MailController.java
@@ -1,0 +1,39 @@
+package com.pknuErrand.appteam.controller;
+
+import com.pknuErrand.appteam.service.MailService;
+import jakarta.mail.MessagingException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.io.UnsupportedEncodingException;
+
+@Controller
+public class MailController {
+    private final MailService mailService;
+    @Autowired
+    MailController(MailService mailService) {
+        this.mailService = mailService;
+    }
+
+    @GetMapping("/mail")
+    public ResponseEntity<String> sendMail(@RequestParam String mail) throws MessagingException, UnsupportedEncodingException {
+        mailService.sendMail(mail);
+        return ResponseEntity.ok()
+                .body("정상적으로 전송 되었습니다.");
+    }
+    @GetMapping("/mail/check")
+    public ResponseEntity<String> checkMailCode(@RequestParam String mail, @RequestParam String code) {
+        mailService.checkCode(mail, code);
+        return ResponseEntity.ok()
+                .body("인증번호 인증 완료.");
+    }
+
+    @GetMapping("/mail/memoryStorageClear")
+    public String clearMemoryStorage() {
+        mailService.clearMemoryStorage();
+        return "인증번호 저장 메모리 스토리지 clear 완료";
+    }
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/Mail/VerificationCode.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/Mail/VerificationCode.java
@@ -1,0 +1,25 @@
+package com.pknuErrand.appteam.domain.Mail;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Getter
+public class VerificationCode {
+
+    private final String code;
+    private final LocalDateTime expiredTime;
+    public VerificationCode() {
+        code = generateCode();
+        expiredTime = LocalDateTime.now().plusMinutes(5);
+    }
+
+    private String generateCode() {
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 6; i++)
+            sb.append(String.valueOf(random.nextInt(10)));
+        return sb.toString();
+    }
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ErrorCode.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ErrorCode.java
@@ -12,8 +12,12 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     ERRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "심부름을 찾을 수 없습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-    RESTRICT_CONTENT_ACCESS(HttpStatus.BAD_REQUEST, "변경할 수 업습니다.");
+    RESTRICT_CONTENT_ACCESS(HttpStatus.BAD_REQUEST, "변경할 수 업습니다."),
 
+    DUPLICATE_DATA(HttpStatus.BAD_REQUEST, "중복된 데이터입니다."),
+    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "양식에 어긋납니다."),
+    INVALID_VALUE(HttpStatus.BAD_REQUEST, "값이 틀립니다."),
+    EXPIRED_TIME(HttpStatus.BAD_REQUEST, "시간이 초과되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/repository/MailMemoryRepository.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/repository/MailMemoryRepository.java
@@ -1,0 +1,34 @@
+package com.pknuErrand.appteam.repository;
+
+import com.pknuErrand.appteam.domain.Mail.VerificationCode;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+public class MailMemoryRepository {
+
+    private Map<String, VerificationCode> storage = new HashMap<>();
+
+    public void save(String mail, VerificationCode code) {
+        storage.put(mail, code);
+    }
+
+    public Boolean isContainsMail(String mail){
+        return storage.containsKey(mail);
+    }
+
+    public Optional<VerificationCode> findByMail(String mail) {
+        return Optional.ofNullable(storage.get(mail));
+    }
+
+    public void remove(String mail) {
+        storage.remove(mail);
+    }
+
+    public void clear() {
+        storage.clear();
+    }
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/MailService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/MailService.java
@@ -1,0 +1,98 @@
+package com.pknuErrand.appteam.service;
+
+import com.pknuErrand.appteam.domain.Mail.VerificationCode;
+import com.pknuErrand.appteam.exception.CustomException;
+import com.pknuErrand.appteam.exception.ErrorCode;
+import com.pknuErrand.appteam.repository.MailMemoryRepository;
+import com.pknuErrand.appteam.repository.member.MemberRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.UnsupportedEncodingException;
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+public class MailService {
+    private final MemberRepository memberRepository;
+    private final MailMemoryRepository mailMemoryRepository;
+    private JavaMailSender mailSender;
+    @Autowired
+    MailService(MemberRepository memberRepository, MailMemoryRepository mailMemoryRepository, JavaMailSender mailSender) {
+        this.memberRepository = memberRepository;
+        this.mailMemoryRepository = mailMemoryRepository;
+        this.mailSender = mailSender;
+    }
+
+    public void sendMail(String mail) throws MessagingException, UnsupportedEncodingException {
+        if(!isValidMailFormat(mail))
+            throw new CustomException(ErrorCode.INVALID_FORMAT, "이메일 포맷은 \"@pukyong.ac.kr\" 이어야 합니다.");
+        if(isDuplicateEmail(mail))
+            throw new CustomException(ErrorCode.DUPLICATE_DATA, "이미 존재하는 이메일입니다.");
+
+        VerificationCode code = new VerificationCode();
+        mailMemoryRepository.save(mail, code);
+        MimeMessage mimeMessage = createMail(mail, code.getCode());
+        mailSender.send(mimeMessage);
+    }
+
+    public void checkCode(String mail, String code) {
+        if(!mailMemoryRepository.isContainsMail(mail))
+            throw new CustomException(ErrorCode.INVALID_VALUE, "인증번호 보내기 요청을 하지않은 mail 입니다.");
+        VerificationCode verificationCode = mailMemoryRepository.findByMail(mail).orElseThrow(() -> new CustomException(ErrorCode.INVALID_VALUE, "저장소에 key(mail)은 저장되어있지만 value(code)가 저장되어있지 않습니다. 백엔드팀에 보고바람."));
+        if(!verificationCode.getCode().equals(code))
+            throw new CustomException(ErrorCode.INVALID_VALUE, "인증번호가 틀립니다.");
+
+        /** 유효시간 over or 인증완료 이므로 삭제 **/
+        mailMemoryRepository.remove(mail);
+
+        if(verificationCode.getExpiredTime().isBefore(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.EXPIRED_TIME, "유효시간 5분이 지났습니다.");
+        }
+    }
+    public void clearMemoryStorage() {
+        mailMemoryRepository.clear();
+    }
+
+    public Boolean isValidMailFormat(String email) {
+        return email.split("@")[1].equals("pukyong.ac.kr");
+    }
+    public Boolean isDuplicateEmail(String mail) {
+        return memberRepository.existsByMail(mail);
+    }
+    public MimeMessage createMail(String mail, String code) throws MessagingException, UnsupportedEncodingException {
+        String setFrom = "ruddbs2410@naver.com";
+        String toEmail = mail;
+        String title = "커카 회원가입 인증번호";
+
+        MimeMessage message = mailSender.createMimeMessage();
+        message.setText("UTF-8", "html");
+        message.addRecipients(MimeMessage.RecipientType.TO, toEmail);
+        message.setSubject(title);
+
+        // 메일 내용
+        String msgOfEmail="";
+        msgOfEmail += "<div style='margin:20px;'>";
+        msgOfEmail += "<h1> 안녕하세요 커카입니커카~ </h1>";
+        msgOfEmail += "<br>";
+        msgOfEmail += "<p>아래 코드를 입력해주세요<p>";
+        msgOfEmail += "<br>";
+        msgOfEmail += "<p>감사합니다.<p>";
+        msgOfEmail += "<br>";
+        msgOfEmail += "<div align='center' style='border:1px solid black; font-family:verdana';>";
+        msgOfEmail += "<h3 style='color:blue;'>회원가입 인증 코드입니다.</h3>";
+        msgOfEmail += "<div style='font-size:130%'>";
+        msgOfEmail += "CODE : <strong>";
+        msgOfEmail += code + "</strong><div><br/> ";
+        msgOfEmail += "</div>";
+
+        message.setFrom(setFrom);
+        message.setText(msgOfEmail, "utf-8", "html");
+
+        return message;
+    }
+}

--- a/server/appteam/src/main/resources/application.properties
+++ b/server/appteam/src/main/resources/application.properties
@@ -9,7 +9,7 @@ spring.datasource.url=jdbc:mariadb://svc.sel5.cloudtype.app:30409/app1
 spring.datasource.username=root
 spring.datasource.password=app1
 
-# ??? ?? ???? ???? ?? ??? ???? ?? ???? ??? ?? ?? ??? ??
+# JWT
 spring.jwt.secret=vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
 
 # Swagger springdoc-ui Configuration
@@ -22,4 +22,14 @@ springdoc.swagger-ui.operations-sorter=alpha
 springdoc.api-docs.path=/api-docs/json
 springdoc.api-docs.groups.enabled=true
 springdoc.cache.disabled=true
+
+# Mail Configuration
+spring.mail.host=smtp.naver.com
+spring.mail.port=465
+spring.mail.username=ruddbs2410@naver.com
+spring.mail.password=Qwer1234!
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.ssl.enable=true
+spring.mail.properties.mail.smtp.ssl.trust=smtp.naver.com
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #83 

### 📝 주요 작업 내용

- 메일주소에 인증번호 메일을 보내기 위한 컨트롤러
   1. 메일주소 format 확인 (@pukyong.ac.kr 포맷인지 확인)
   2. 이미 존재하는 메일인지 확인 (이미 가입된 메일인지 확인)
   3. VerificationCode 객체 생성 (객체 생성 시 기본 생성자로 인증번호와 유효시간이 필드값으로 저장됨)
   4. mailMemoryRepository (인메모리 저장소)에 mail, VerificationCode 저장
         - 해당 저장소에 Map<mail, VerificationCode> 형태로 저장된다.
   5. 정해둔 양식에 맞춰 코드가 담긴 메일을 해당 메일주소로 전송 (MimeMessage)
   6. JavaMailSender를 통해서 메일 전송 

- 인증번호 확인을 위한 컨트롤러
   1. 저장소에 저장되어있는 이메일인지 확인 (인증번호 보내기를 누르지않은 메일주소)
   2. 저장소에 메일주소는 저장되어있지만 code가 저장되어있지 않는가 확인
   3. 저장소에 저장된 인증번호와 요청받은 인증번호 확인
   4. 위 내용을 통과하였다면 메모리 저장소에서 해당하는 엔트리 삭제
       - 유효시간이 지났거나, 이미 완료될 인증이므로 메모리에서 삭제 가능
   5. VerificationCode 내의 expiredTime 필드를 통해 유효시간이 지났는지 검증
   6. 다 통과하였다면 클라이언트에 http status 200 ok 전송

- 메모리 저장소를 비우는 컨트롤러
   - 이메일 요청만 보내고 인증을 하지 않는 사용자가 있다면 메모리가 불필요하게 낭비됨
   - 관리자가 임의로 메모리 저장소를 비워주는 방식 선택

