### PR TITLE
feature/86 mailController clearMemoryStorage 기능 변경

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/MailController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/MailController.java
@@ -32,8 +32,8 @@ public class MailController {
     }
 
     @GetMapping("/mail/memoryStorageClear")
-    public String clearMemoryStorage() {
-        mailService.clearMemoryStorage();
-        return "인증번호 저장 메모리 스토리지 clear 완료";
+    public String clearExpiredEntryInMemoryStorage() {
+        mailService.clearExpiredEntryInMemoryStorage();
+        return "인증번호 저장 메모리 스토리지 내 유효시간이 지난 데이터 clear 완료";
     }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/repository/MailMemoryRepository.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/repository/MailMemoryRepository.java
@@ -1,12 +1,14 @@
 package com.pknuErrand.appteam.repository;
 
 import com.pknuErrand.appteam.domain.Mail.VerificationCode;
+import lombok.Getter;
 import org.springframework.stereotype.Repository;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+@Getter
 @Repository
 public class MailMemoryRepository {
 
@@ -26,9 +28,5 @@ public class MailMemoryRepository {
 
     public void remove(String mail) {
         storage.remove(mail);
-    }
-
-    public void clear() {
-        storage.clear();
     }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/MailService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/MailService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Service
 @Transactional
@@ -54,8 +55,12 @@ public class MailService {
             throw new CustomException(ErrorCode.EXPIRED_TIME, "유효시간 5분이 지났습니다.");
         }
     }
-    public void clearMemoryStorage() {
-        mailMemoryRepository.clear();
+    public void clearExpiredEntryInMemoryStorage() {
+        Map<String, VerificationCode> map = mailMemoryRepository.getStorage();
+        for(Map.Entry<String, VerificationCode> entry : map.entrySet()) {
+            if(entry.getValue().getExpiredTime().isBefore(LocalDateTime.now()))
+                mailMemoryRepository.remove(entry.getKey());
+        }
     }
 
     public Boolean isValidMailFormat(String email) {


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #86 

### 📝 주요 작업 내용

- 메소드 이름 변경 : clearMemoryStorage() -> clearExpiredEntryInMemoryStorage()

- 기존에는 메모리 저장소를 완전히 clear() 시켰었지만 지금은 entry를 순회하며 인증코드가 expired된 엔트리만 삭제함

- 메인 로직
![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/0d6e00c5-ae0a-48ba-81eb-11df9fee033c)

