### PR TITLE
feature/88 errand email 예외 변경 알맞는 상태코드 전달

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomExceptionHandler.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomExceptionHandler.java
@@ -13,7 +13,7 @@ public class CustomExceptionHandler {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ExceptionResponseDto> customExceptionHandler(CustomException e) {
 
-        log.error("{} / {} / {}\n\n", e.getName(), e.getHttpStatus(), e.getMessage());
+        log.warn("{} / {} / {}\n\n", e.getName(), e.getHttpStatus(), e.getMessage());
 
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ExceptionResponseDto.builder()
@@ -29,11 +29,11 @@ public class CustomExceptionHandler {
         log.error("Exception / {}", e.getMessage());
         e.printStackTrace();
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ExceptionResponseDto.builder()
                         .name(e.toString().split(":")[0])
-                        .httpStatus(HttpStatus.BAD_REQUEST)
-                        .message(e.getMessage())
+                        .httpStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .message(e.getMessage() + "\n계속 발생하면 백엔드팀에 문의하셈")
                         .build());
     }
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandRepository.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandRepository.java
@@ -11,14 +11,14 @@ public interface ErrandRepository extends JpaRepository<Errand, Long> {
 
     @Query(value = "SELECT * " +
             "FROM errand " +
-            "WHERE (created_date = :cursor AND errand_no > :pk) OR created_date > :cursor " +
-            "ORDER BY created_date ASC, errand_no DESC LIMIT :limit", nativeQuery = true)
+            "WHERE (created_date = :cursor AND errand_no > :pk) OR created_date < :cursor " +
+            "ORDER BY created_date DESC, errand_no DESC LIMIT :limit", nativeQuery = true)
     List<Errand> findErrandByLatest(@Param("pk") Long pk, @Param("cursor") String cursor, @Param("limit") int limit);
 
     @Query(value = "SELECT * " +
             "FROM errand " +
-            "WHERE (status = :status) AND ((created_date = :cursor AND errand_no > :pk) OR created_date > :cursor) " +
-            "ORDER BY created_date ASC, errand_no DESC LIMIT :limit", nativeQuery = true)
+            "WHERE (status = :status) AND ((created_date = :cursor AND errand_no > :pk) OR created_date < :cursor) " +
+            "ORDER BY created_date DESC, errand_no DESC LIMIT :limit", nativeQuery = true)
     List<Errand> findErrandByStatusAndLatest(@Param("pk") Long pk, @Param("cursor") String cursor, @Param("limit") int limit,
                                              @Param("status") String status);
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #88 

### 📝 주요 작업 내용

- 핸들링 한 예외 이외 나머지 예외 발생시 http status code를 500번대로 클라이언트에 보냄

- pagination 시 데이터 포맷에 따른 예외 추가

- 핸들링 하는 예외중 커스텀 예외가 아닌것들을 정확한 에러 내용을 알 수 있는 customException으로 변경

- 확인중 페이지네이션 최신순이 아니라 오래된 순으로 나오길래 버그 수정

