### PR TITLE
feature/91-심부름-정렬하여-불러오기-기능-분리

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -60,11 +60,18 @@ public class ErrandController {
                 .body(errandService.findErrandById(id));
     }
 
-    @Operation(summary = "메인화면 요청서 불러오기 (무한스크롤)", description = "정렬방법, 커서위치, 게시물 갯수를 입력받아 요청서를 불러온다")
-    @GetMapping
-    public ResponseEntity<List<ErrandListResponseDto>> getPaginationErrand(ErrandPaginationRequestVo pageInfo) {
+    @Operation(summary = "최신순으로 페이지네이션 불러오기")
+    @GetMapping("/latest")
+    public ResponseEntity<List<ErrandListResponseDto>> getPaginationErrandByLatest(ErrandPaginationRequestVo pageInfo) {
         return ResponseEntity.ok()
-                .body(errandService.findPaginationErrand(pageInfo));
+                .body(errandService.findPaginationErrandByLatest(pageInfo));
+    }
+
+    @Operation(summary = "금액순으로 페이지네이션 불러오기")
+    @GetMapping("/reward")
+    public ResponseEntity<List<ErrandListResponseDto>> getPaginationErrandByReward(ErrandPaginationRequestVo pageInfo) {
+        return ResponseEntity.ok()
+                .body(errandService.findPaginationErrandByReward(pageInfo));
     }
 
     @Operation(summary = "요청서 수락하기", description = "요청서 수락요청을 통해 errand status 변경하기")

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandPaginationRequestVo.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/getDto/ErrandPaginationRequestVo.java
@@ -12,5 +12,4 @@ public class ErrandPaginationRequestVo {
     private String cursor;
     private int limit;
     private Status status;
-    private Sort sort;
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #91 

### 📝 주요 작업 내용

1. 페이지네이션 불러오기 기능의 api와 서비스 메소드를 분리하였음
  - 기존 페이지네이션 불러오기 기능은 어떤 정렬로 불러올것인지 파라미터로 받아와서 기능을 나누어 응답했음
  - 한 api와 메소드에 코드가 몰려 가독성이 굉장히 떨어짐
  - sort 파라미터의 값에 따라 cursor 파라미터의 데이터 포맷을 다르게 받아와야하는데 이 때 프론트 입장에서 불편할것이라 생각

2. Errand의 모든정보 (사용자나 프론트에 노출되면 안되거나 노출될 필요가 없는 ex) 글쓴이의 비밀번호 등)를 가지는 Errand List를 통해 필요한 정보만 가지는 ErrandListResponseDto list로 바꾸는 과정을 하나의 메소드로 분리함
  - 생각보다 여러 api에서 해당 기능을 사용하여, 메소드로 분리하여 가독성과 코드량을 줄였음.
  - 메소드 이름을 고민하다 ChatGPT의 명쾌한 답변으로 단번에 정해버림 -> "getFilteredErrandList()"
