### PR TITLE
feature/93 api 문서화를 위한 swagger 추가 설정 및 ExceptionHandler 추가

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/MailController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/MailController.java
@@ -1,6 +1,14 @@
 package com.pknuErrand.appteam.controller;
 
+import com.pknuErrand.appteam.dto.errand.getDto.ErrandDetailResponseDto;
+import com.pknuErrand.appteam.exception.ExceptionResponseDto;
 import com.pknuErrand.appteam.service.MailService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.MessagingException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.io.UnsupportedEncodingException;
 
+@Tag(name = "Mail", description = "Mail 인증 관련 API")
 @Controller
 public class MailController {
     private final MailService mailService;
@@ -18,12 +27,26 @@ public class MailController {
         this.mailService = mailService;
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "메일 전송 성공", content = @Content(mediaType = "정상적으로 전송 되었습니다.")) ,
+            @ApiResponse(responseCode = "400\nDUPLICATE_DATA", description = "이미 존재하는 메일", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+            @ApiResponse(responseCode = "415\nINVALID_FORMAT", description = "메일 주소 format 잘못됨", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class)))
+    })
+    @Operation(summary = "메일로 인증번호 전송" , description = "메일로 인증번호 전송")
     @GetMapping("/mail")
     public ResponseEntity<String> sendMail(@RequestParam String mail) throws MessagingException, UnsupportedEncodingException {
         mailService.sendMail(mail);
         return ResponseEntity.ok()
                 .body("정상적으로 전송 되었습니다.");
     }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인증번호 인증 성공", content = @Content(mediaType = "인증번호 인증 완료.")) ,
+            @ApiResponse(responseCode = "400\nINVALID_VALUE", description = "인증번호가 틀립니다.", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+            @ApiResponse(responseCode = "404\nMAIL_NOT_FOUND", description = "해당 메일주소 찾을 수 없음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+            @ApiResponse(responseCode = "408\nEXPIRED_TIME", description = "인증번호 시간초과", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+    })
+    @Operation(summary = "인증번호 인증" , description = "메일로 보낸 인증번호 인증")
     @GetMapping("/mail/check")
     public ResponseEntity<String> checkMailCode(@RequestParam String mail, @RequestParam String code) {
         mailService.checkCode(mail, code);

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -6,9 +6,14 @@ import com.pknuErrand.appteam.dto.errand.getDto.ErrandDetailResponseDto;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandPaginationRequestVo;
 import com.pknuErrand.appteam.dto.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.domain.member.Member;
+import com.pknuErrand.appteam.exception.ExceptionResponseDto;
 import com.pknuErrand.appteam.service.errand.ErrandService;
 import com.pknuErrand.appteam.service.member.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +39,9 @@ public class ErrandController {
     }
 
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공", content = @Content(schema = @Schema(implementation = ErrandDetailResponseDto.class))) ,
+    })
     @Operation(summary = "요청서 등록" , description = "심부름 요청서 등록")
     @PostMapping
     public ResponseEntity<?> createErrand(@RequestBody ErrandSaveRequestDto errandSaveRequestDto) {
@@ -41,6 +49,11 @@ public class ErrandController {
                 .body(errandService.createErrand(errandSaveRequestDto));
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "불러오기 성공", content = @Content(schema = @Schema(implementation = ErrandListResponseDto.class))) ,
+            @ApiResponse(responseCode = "400\nINVALID_VALUE", description = "limit 값이 잘못되었음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+            @ApiResponse(responseCode = "415\nINVALID_FORMAT", description = "Cursor format이 잘못되었음(날짜/시간)", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+    })
     @Operation(summary = "최신순으로 페이지네이션 불러오기")
     @GetMapping("/latest")
     public ResponseEntity<List<ErrandListResponseDto>> getPaginationErrandByLatest(ErrandPaginationRequestVo pageInfo) {
@@ -48,6 +61,11 @@ public class ErrandController {
                 .body(errandService.findPaginationErrandByLatest(pageInfo));
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "불러오기 성공", content = @Content(schema = @Schema(implementation = ErrandListResponseDto.class))) ,
+            @ApiResponse(responseCode = "400\nINVALID_VALUE", description = "limit 값이 잘못되었거나 Cursor가 0보다 작음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+            @ApiResponse(responseCode = "415\nINVALID_FORMAT", description = "Cursor format이 잘못되었음(금액)", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+    })
     @Operation(summary = "금액순으로 페이지네이션 불러오기")
     @GetMapping("/reward")
     public ResponseEntity<List<ErrandListResponseDto>> getPaginationErrandByReward(ErrandPaginationRequestVo pageInfo) {
@@ -55,7 +73,12 @@ public class ErrandController {
                 .body(errandService.findPaginationErrandByReward(pageInfo));
     }
 
-
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수락 성공", content = @Content(schema = @Schema(implementation = ErrandDetailResponseDto.class))) ,
+            @ApiResponse(responseCode = "404\nERRAND_NOT_FOUND", description = "심부름 찾을 수 없음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+            @ApiResponse(responseCode = "401\nUNAUTHORIZED_ACCESS", description = "본인 게시물 수락할 수 없음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+            @ApiResponse(responseCode = "406\nRESTRICT_CONTENT_ACCESS", description = "진행중/완료 상태인 심부름 수락 불가능", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+    })
     @Operation(summary = "요청서 수락하기", description = "요청서 수락요청을 통해 errand status 변경하기")
     @GetMapping("/{id}/accept")
     public ResponseEntity<ErrandDetailResponseDto> acceptErrand(@PathVariable Long id) {
@@ -63,7 +86,12 @@ public class ErrandController {
                 .body(errandService.acceptErrand(id));
     }
 
-
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(schema = @Schema(implementation = ErrandDetailResponseDto.class))) ,
+            @ApiResponse(responseCode = "404\nERRAND_NOT_FOUND", description = "심부름 찾을 수 없음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+            @ApiResponse(responseCode = "401\nUNAUTHORIZED_ACCESS", description = "본인 게시물이 아니면 수정 불가능", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+            @ApiResponse(responseCode = "406\nRESTRICT_CONTENT_ACCESS", description = "진행중/완료 상태인 심부름 수정 불가능", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+    })
     @Operation(summary = "요청서 수정하기", description = "요청서 수정을 통해 errand field 변경하기")
     @PutMapping("/{id}")
     public ResponseEntity<ErrandDetailResponseDto> updateErrand(@PathVariable Long id, @RequestBody ErrandSaveRequestDto errandSaveRequestDto) {
@@ -71,6 +99,12 @@ public class ErrandController {
                 .body(errandService.updateErrand(id, errandSaveRequestDto));
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content(schema = @Schema(implementation = ErrandDetailResponseDto.class))) ,
+            @ApiResponse(responseCode = "404\nERRAND_NOT_FOUND", description = "심부름 찾을 수 없음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+            @ApiResponse(responseCode = "401\nUNAUTHORIZED_ACCESS", description = "본인 게시물이 아니면 삭제 불가능", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+            @ApiResponse(responseCode = "406\nRESTRICT_CONTENT_ACCESS", description = "진행중/완료 상태인 심부름 삭제 불가능", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+    })
     @Operation(summary = "요청서 삭제하기", description = "요청서 삭제")
     @DeleteMapping("/{id}")
     public void deleteErrand(@PathVariable Long id) {

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -41,10 +42,11 @@ public class ErrandController {
 
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "저장 성공", content = @Content(schema = @Schema(implementation = ErrandDetailResponseDto.class))) ,
+            @ApiResponse(responseCode = "415", description = "데이터가 잘못되었음 (공백 , null 등)", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
     })
     @Operation(summary = "요청서 등록" , description = "심부름 요청서 등록")
     @PostMapping
-    public ResponseEntity<?> createErrand(@RequestBody ErrandSaveRequestDto errandSaveRequestDto) {
+    public ResponseEntity<?> createErrand(@Valid @RequestBody ErrandSaveRequestDto errandSaveRequestDto) {
         return ResponseEntity.ok()
                 .body(errandService.createErrand(errandSaveRequestDto));
     }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/dto/errand/saveDto/ErrandSaveRequestDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/dto/errand/saveDto/ErrandSaveRequestDto.java
@@ -1,5 +1,9 @@
 package com.pknuErrand.appteam.dto.errand.saveDto;
 
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,22 +19,31 @@ public class ErrandSaveRequestDto { // to Entity
      *  게시글 등록하는 member의 정보는 jwt에서 추출
      */
 
+    @NotBlank(message = "등록일을 입력하세요.")
     private String createdDate; // 등록한 date
 
+    @NotBlank(message = "제목을 입력하세요.")
     private String title;
 
+    @NotBlank(message = "도착지를 입력하세요.")
     private String destination;
 
+    @NotNull(message = "latitude를 입력하세요.")
     private double latitude;
 
+    @NotNull(message = "longitude를 입력하세요.")
     private double longitude;
 
+    @NotNull(message = "마감시간을 입력하세요.")
     private Timestamp due; // 몇시까지?
 
+    @NotBlank(message = "상세내용을 입력하세요.")
     private String detail;
 
+    @PositiveOrZero(message = "보수금액을 입력하세요.")
     private int reward;
 
+    @NotNull(message = "현금인지 아닌지 입력하세요.")
     private boolean isCash;
 
     // private Status status;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomExceptionHandler.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomExceptionHandler.java
@@ -3,6 +3,9 @@ package com.pknuErrand.appteam.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -20,6 +23,23 @@ public class CustomExceptionHandler {
                         .code(e.getCode())
                         .httpStatus(e.getHttpStatus())
                         .message(e.getMessage())
+                        .build());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponseDto> validExceptionHandler(MethodArgumentNotValidException e) {
+
+        FieldError fieldError = e.getBindingResult().getFieldError();
+        String message = fieldError.getDefaultMessage() + " / " + fieldError.getField() + " = " + fieldError.getRejectedValue();
+
+        log.warn("Valid Exception / {}\n\n", message);
+
+
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+                .body(ExceptionResponseDto.builder()
+                        .code("Valid Exception")
+                        .httpStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+                        .message(message)
                         .build());
     }
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomExceptionHandler.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/CustomExceptionHandler.java
@@ -17,7 +17,7 @@ public class CustomExceptionHandler {
 
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ExceptionResponseDto.builder()
-                        .name(e.getCode())
+                        .code(e.getCode())
                         .httpStatus(e.getHttpStatus())
                         .message(e.getMessage())
                         .build());
@@ -31,7 +31,7 @@ public class CustomExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ExceptionResponseDto.builder()
-                        .name(e.toString().split(":")[0])
+                        .code(e.toString().split(":")[0])
                         .httpStatus(HttpStatus.INTERNAL_SERVER_ERROR)
                         .message(e.getMessage() + "\n계속 발생하면 백엔드팀에 문의하셈")
                         .build());

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ErrorCode.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ErrorCode.java
@@ -11,13 +11,17 @@ public enum ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     ERRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "심부름을 찾을 수 없습니다."),
+    MAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "메일을 찾을 수 없습니다."),
+
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
-    RESTRICT_CONTENT_ACCESS(HttpStatus.BAD_REQUEST, "변경할 수 업습니다."),
+    RESTRICT_CONTENT_ACCESS(HttpStatus.NOT_ACCEPTABLE, "변경할 수 업습니다."),
 
     DUPLICATE_DATA(HttpStatus.BAD_REQUEST, "중복된 데이터입니다."),
-    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "양식에 어긋납니다."),
-    INVALID_VALUE(HttpStatus.BAD_REQUEST, "값이 틀립니다."),
-    EXPIRED_TIME(HttpStatus.BAD_REQUEST, "시간이 초과되었습니다.");
+    INVALID_FORMAT(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "양식에 어긋납니다."),
+    INVALID_VALUE(HttpStatus.BAD_REQUEST, "입력값이 틀립니다."),
+    EXPIRED_TIME(HttpStatus.REQUEST_TIMEOUT, "시간이 초과되었습니다."),
+
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ExceptionResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/exception/ExceptionResponseDto.java
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 @Getter
 @Builder
 public class ExceptionResponseDto {
-    private final String name;
+    private final String code;
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/MailService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/MailService.java
@@ -43,8 +43,8 @@ public class MailService {
 
     public void checkCode(String mail, String code) {
         if(!mailMemoryRepository.isContainsMail(mail))
-            throw new CustomException(ErrorCode.INVALID_VALUE, "인증번호 보내기 요청을 하지않은 mail 입니다.");
-        VerificationCode verificationCode = mailMemoryRepository.findByMail(mail).orElseThrow(() -> new CustomException(ErrorCode.INVALID_VALUE, "저장소에 key(mail)은 저장되어있지만 value(code)가 저장되어있지 않습니다. 백엔드팀에 보고바람."));
+            throw new CustomException(ErrorCode.MAIL_NOT_FOUND, "해당 mail을 찾을 수 없습니다.");
+        VerificationCode verificationCode = mailMemoryRepository.findByMail(mail).orElseThrow(() -> new CustomException(ErrorCode.SERVER_ERROR, "저장소에 key(mail)은 저장되어있지만 value(code)가 저장되어있지 않습니다. 백엔드팀에 보고바람."));
         if(!verificationCode.getCode().equals(code))
             throw new CustomException(ErrorCode.INVALID_VALUE, "인증번호가 틀립니다.");
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -156,6 +156,9 @@ public class ErrandService {
         /** 본인 게시물이라면 예외 발생 **/
         if(errand.getOrderNo().getMemberNo() == errander.getMemberNo())
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS, "본인 게시물을 수락할 수 없습니다.");
+        if(!errand.getStatus().equals(RECRUITING)) {
+            throw new CustomException(ErrorCode.RESTRICT_CONTENT_ACCESS, "진행중이거나 완료된 심부름은 수락이 불가능합니다.");
+        }
         changeErrandStatusAndSetErrander(errand, Status.IN_PROGRESS, errander);
         return findErrandById(id);
     }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #93 

### 📝 주요 작업 내용

1. 스웨거 api에 성공 reponse 이외에 실패 response 예시 추가하였음 (상태코드)
2. 하나의 api에서 http status code와 body로 전달되는 code도 똑같은 경우 프론트에서 구분할 수 없기 때문에 http status code와 code를 수정/추가 하였음.
![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/e864fcf7-0b5f-457d-bab6-935280f422b5)

3. 심부름 등록시 공백이나 빈칸은 허용하지않도록 @Valid 어노테이션을 통해 처리하였음.
4. @Valid 어노테이션에서 필터링 될 시 MethodArgumentNotValidException 가 발생하는데,  이 예외를 관리하는 @ExceptionHandle를 추가하였음. 프론트에 415 에러코드 (UNSUPPORTED_MEDIA_TYPE)가 전달되고 발생이유 등이 전달됨
![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/e6384795-0ccc-4f16-967f-4bf7eb978346)

