### PR TITLE
Feature/120 websocket config 및 status entity 추가

### DIFF
--- a/server/appteam/build.gradle
+++ b/server/appteam/build.gradle
@@ -16,6 +16,8 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation('org.projectlombok:lombok')
 	// security

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/config/WebSocketConfig.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/config/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.pknuErrand.appteam.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/queue");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/status/Status.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/status/Status.java
@@ -1,0 +1,43 @@
+package com.pknuErrand.appteam.domain.status;
+
+import com.pknuErrand.appteam.domain.errand.Errand;
+import com.pknuErrand.appteam.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "Status")
+public class Status {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @Column
+    private long statusNo;
+
+    @ManyToOne
+    @JoinColumn
+    private Member erranderNo; // 심부름 꾼
+
+    @ManyToOne
+    @JoinColumn
+    private Errand errandNo;
+
+    @Column
+    private String contents; // 현황 정보
+
+    @Column
+    private LocalDateTime created;
+
+    @Builder
+    public Status(Member erranderNo, Errand errandNo, String contents) {
+        this.erranderNo = erranderNo;
+        this.errandNo = errandNo;
+        this.contents = contents;
+        this.created = LocalDateTime.now();
+    }
+
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #120 

### 📝 주요 작업 내용


- WebSocketConfig 추가
  - simple broker endpoint (클라이언트로 전송할 엔드포인트) "/queue" 로 설정
  - ApplicationDestinationPrefixes (정보 저장, 가공을 위한 서버에서 받을 엔드포인트) "/app" 으로 설정
- Status Entity 추가
  - created(생성시각) 은 LocalDateTime.now()를 생성자로 넣어줬음


### 🖼️ 스크린샷 (선택)
![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/408d0778-969e-4bff-a129-2f87444e39bd)
