### PR TITLE
feature/131-jwt-토큰-검증-api-추가

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/UtilityController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/UtilityController.java
@@ -1,0 +1,16 @@
+package com.pknuErrand.appteam.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+@Tag(name = "Utility", description = "etc API")
+@Controller
+public class UtilityController {
+
+    @GetMapping("/token/isValid")
+    public ResponseEntity<String> isValidToken() {
+        return ResponseEntity.ok()
+                .body("ok");
+    }
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -124,14 +124,6 @@ public class ErrandController {
         errandService.deleteErrand(id);
     }
 
-    @GetMapping("/loginTest")
-    public void 로그인테스트() {
-        Member member = memberService.getLoginMember();
-        log.info("member id = {}", member.getId());
-        log.info("member name = {}", member.getName());
-        if(member == null)
-            log.warn("member is null");
-    }
 
     @GetMapping("/all")
     public ResponseEntity<List<ErrandListResponseDto>> getAllErrand() {

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/mail/MailController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/mail/MailController.java
@@ -53,6 +53,8 @@ public class MailController {
                 .body("인증번호 인증 완료.");
     }
 
+
+    @Operation(summary = "인증번호 저장 메모리 스토리지 내 유효시간이 지난 데이터 clear" )
     @GetMapping("/mail/memoryStorageClear")
     public String clearExpiredEntryInMemoryStorage() {
         mailService.clearExpiredEntryInMemoryStorage();


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #131 

### 📝 주요 작업 내용

-  jwt 토큰 검증 api 추가
  - 프론트에서 자동 로그인 구현을 위해서 만듬
  - 앱 실행시 메인페이지에 관한 요청을 하고 에러코드를 보고 로그인페이지로 Navigator 할 수도 있지만 코드상 백엔드에서 api를 추가하는게 더 깔끔했음
  - **response http code가 200일 때 검증된 토큰, 403일 때 forbidden된 토큰**
