### PR TITLE
feature/133 사용자의 진행중인 심부름 확인 목록 불러오기 api 추가

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/UtilityController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/UtilityController.java
@@ -1,5 +1,12 @@
 package com.pknuErrand.appteam.controller;
 
+import com.pknuErrand.appteam.dto.errand.getDto.ErrandDetailResponseDto;
+import com.pknuErrand.appteam.exception.ExceptionResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -8,6 +15,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class UtilityController {
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유효한 토큰") ,
+            @ApiResponse(responseCode = "403", description = "유효하지 않은 토큰") ,
+    })
+    @Operation(summary = "유효한 토큰인지 검증")
     @GetMapping("/token/isValid")
     public ResponseEntity<String> isValidToken() {
         return ResponseEntity.ok()

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -4,6 +4,7 @@ package com.pknuErrand.appteam.controller.errand;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandListResponseDto;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandDetailResponseDto;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandPaginationRequestVo;
+import com.pknuErrand.appteam.dto.errand.getDto.InProgressErrandListResponseDto;
 import com.pknuErrand.appteam.dto.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.exception.ExceptionResponseDto;
@@ -130,11 +131,20 @@ public class ErrandController {
             @ApiResponse(responseCode = "404", description = "진행중인 심부름 없음") ,
     })
     @Operation(summary = "사용자의 진행중인 심부름 여부 확인")
-    @GetMapping("/in-progress")
+    @GetMapping("/in-progress/exist")
     public ResponseEntity<Void> checkInProgressErrandExist() {
         errandService.checkInProgressErrandExist();
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "사용자의 진행중인 심부름 불러오기")
+    @GetMapping("/in-progress")
+    public ResponseEntity<List<InProgressErrandListResponseDto>> getInProgressErrand() {
+        List<InProgressErrandListResponseDto> list = errandService.getInProgressErrand();
+        return ResponseEntity.ok()
+                .body(list);
+    }
+
 
     @GetMapping("/all")
     public ResponseEntity<List<ErrandListResponseDto>> getAllErrand() {

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -120,10 +120,21 @@ public class ErrandController {
     })
     @Operation(summary = "요청서 삭제하기", description = "요청서 삭제")
     @DeleteMapping("/{id}")
-    public void deleteErrand(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteErrand(@PathVariable Long id) {
         errandService.deleteErrand(id);
+        return ResponseEntity.ok().build();
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "진행중인 심부름 있음") ,
+            @ApiResponse(responseCode = "404", description = "진행중인 심부름 없음") ,
+    })
+    @Operation(summary = "사용자의 진행중인 심부름 여부 확인")
+    @GetMapping("/in-progress")
+    public ResponseEntity<Void> checkInProgressErrandExist() {
+        errandService.checkInProgressErrandExist();
+        return ResponseEntity.ok().build();
+    }
 
     @GetMapping("/all")
     public ResponseEntity<List<ErrandListResponseDto>> getAllErrand() {

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -137,6 +137,10 @@ public class ErrandController {
         return ResponseEntity.ok().build();
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "진행중인 심부름 있음", content = @Content(schema = @Schema(implementation = InProgressErrandListResponseDto.class))) ,
+            @ApiResponse(responseCode = "404", description = "진행중인 심부름 없음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+    })
     @Operation(summary = "사용자의 진행중인 심부름 불러오기")
     @GetMapping("/in-progress")
     public ResponseEntity<List<InProgressErrandListResponseDto>> getInProgressErrand() {

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/dto/errand/getDto/InProgressErrandListResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/dto/errand/getDto/InProgressErrandListResponseDto.java
@@ -1,0 +1,19 @@
+package com.pknuErrand.appteam.dto.errand.getDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InProgressErrandListResponseDto {
+    private long errandNo;
+    private String title;
+    private Timestamp due;
+    private Boolean isUserOrder;
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandRepository.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandRepository.java
@@ -1,5 +1,6 @@
 package com.pknuErrand.appteam.repository.errand;
 import com.pknuErrand.appteam.domain.errand.Errand;
+import com.pknuErrand.appteam.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -33,5 +34,10 @@ public interface ErrandRepository extends JpaRepository<Errand, Long> {
             "ORDER BY reward DESC, errand_no DESC LIMIT :limit", nativeQuery = true)
     List<Errand> findErrandByStatusAndReward(@Param("pk") Long pk, @Param("cursor") int cursor, @Param("limit") int limit,
                                               @Param("status") String status);
+
+    @Query(value = "SELECT * " +
+            "FROM errand " +
+            "WHERE ((errander_no_member_no =:memberNo) OR (order_no_member_no =:memberNo)) AND (status = 'IN_PROGRESS')", nativeQuery = true)
+    List<Errand> findInProgressErrand(@Param("memberNo") Long memberNo);
 
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -6,6 +6,7 @@ import com.pknuErrand.appteam.Enum.Status;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandListResponseDto;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandDetailResponseDto;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandPaginationRequestVo;
+import com.pknuErrand.appteam.dto.errand.getDto.InProgressErrandListResponseDto;
 import com.pknuErrand.appteam.dto.errand.saveDto.ErrandSaveRequestDto;
 import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.dto.member.MemberErrandDto;
@@ -225,7 +226,26 @@ public class ErrandService {
         List<Errand> inProgressErrandList = errandRepository.findInProgressErrand(member.getMemberNo());
         if(inProgressErrandList.size() == 0)
             throw new CustomException(ErrorCode.ERRAND_NOT_FOUND);
-        for(Errand errand: inProgressErrandList)
-            System.out.println(errand.getErrandNo());
+//        for(Errand errand: inProgressErrandList)
+//            System.out.println(errand.getErrandNo());
+    }
+
+    @Transactional
+    public List<InProgressErrandListResponseDto> getInProgressErrand() {
+        Member member = memberService.getLoginMember();
+        List<Errand> inProgressErrandList = errandRepository.findInProgressErrand(member.getMemberNo());
+        if(inProgressErrandList.size() == 0)
+            throw new CustomException(ErrorCode.ERRAND_NOT_FOUND);
+        List<InProgressErrandListResponseDto> filteredinProgressErrandList = new ArrayList<>();
+        for(Errand errand : inProgressErrandList) {
+            InProgressErrandListResponseDto filteredErrand = InProgressErrandListResponseDto.builder()
+                    .errandNo(errand.getErrandNo())
+                    .title(errand.getTitle())
+                    .due(errand.getDue())
+                    .isUserOrder(errand.getOrderNo().equals(member))
+                    .build();
+            filteredinProgressErrandList.add(filteredErrand);
+        }
+        return filteredinProgressErrandList;
     }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -218,4 +218,14 @@ public class ErrandService {
         }
         errandRepository.delete(errand);
     }
+
+    @Transactional
+    public void checkInProgressErrandExist() {
+        Member member = memberService.getLoginMember();
+        List<Errand> inProgressErrandList = errandRepository.findInProgressErrand(member.getMemberNo());
+        if(inProgressErrandList.size() == 0)
+            throw new CustomException(ErrorCode.ERRAND_NOT_FOUND);
+        for(Errand errand: inProgressErrandList)
+            System.out.println(errand.getErrandNo());
+    }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #133 

### 📝 주요 작업 내용

- 해당 사용자에게 진행중인 심부름이 있는지 확인하는 api
   - Method : GET
   - End Point : /in-progress/exist
   - 있다면 200 ok, 없다면 404 not found
 
- 해당 사용자의 진행중인 심부름 리스트를 반환하는 api
   - Method : GET
   - End Point : /in-progress
   - 성공시 200 ok + InProgressErrandListResponseDto의 list 응답
     - InProgressErrandListResponseDto 에는 pk, 제목, 일정, 유저가 order인지 아닌지의 정보가 담긴 필드 존재
   - 진행중인 심부름이 없다면 404 not found

- Repository에서 쿼리메소드를 쓰려했으나 조건이 복잡하여 직관적인 native query 사용
![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/83b20dd2-17aa-4244-b7f0-d417bd0f79de)


