### PR TITLE
feature/136 현황 페이지 관련 api 추가

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/statusMessage/StatusMessageController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/statusMessage/StatusMessageController.java
@@ -2,14 +2,30 @@ package com.pknuErrand.appteam.controller.statusMessage;
 
 
 import com.pknuErrand.appteam.domain.statusMessage.StatusMessage;
+import com.pknuErrand.appteam.dto.errand.getDto.ErrandDetailResponseDto;
 import com.pknuErrand.appteam.dto.statusMessage.StatusMessageRequestDto;
 import com.pknuErrand.appteam.dto.statusMessage.StatusMessageResponseDto;
+import com.pknuErrand.appteam.exception.ExceptionResponseDto;
 import com.pknuErrand.appteam.service.statusMessage.StatusMessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
+import java.util.List;
+
+@Slf4j
+@Tag(name = "Status Message", description = "현황 페이지 관련 API")
 @Controller
 public class StatusMessageController {
 
@@ -21,7 +37,19 @@ public class StatusMessageController {
     @MessageMapping("/{errandNo}") // /app/{errandId}
     @SendTo("/queue/{errandNo}")
     public StatusMessageResponseDto message(@DestinationVariable Long errandNo, StatusMessageRequestDto statusMessageRequestDto) {
-        StatusMessage message = statusMessageService.saveStatusMessage(statusMessageRequestDto);
+        StatusMessage message = statusMessageService.saveStatusMessage(statusMessageRequestDto, errandNo);
+        log.info(message.getContents());
         return new StatusMessageResponseDto(message);
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "불러오기 성공", content = @Content(schema = @Schema(implementation = StatusMessageResponseDto.class))) ,
+            @ApiResponse(responseCode = "401\nUNAUTHORIZED_ACCESS", description = "권한이 없는 사용자", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+    })
+    @Operation(summary = "현황페이지 메시지내역 불러오기" , description = "웹소켓 연결 전 불러와야함")
+    @GetMapping("/statusMessage/{errandNo}")
+    public ResponseEntity<List<StatusMessageResponseDto>> getStatusMessageList(@PathVariable Long errandNo) {
+        return ResponseEntity.ok()
+                .body(statusMessageService.getStatusMessageList(errandNo));
     }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/dto/statusMessage/StatusMessageRequestDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/dto/statusMessage/StatusMessageRequestDto.java
@@ -12,8 +12,8 @@ import lombok.NoArgsConstructor;
 public class StatusMessageRequestDto {
     private Long erranderNo; // 심부름 꾼
 
-    private Long errandNo; // 심부름 번호
+ //   private Long errandNo; // 심부름 번호
 
-    private String contents; // 현황 정보
+    private String contents; // 메세지
 
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/dto/statusMessage/StatusMessageResponseDto.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/dto/statusMessage/StatusMessageResponseDto.java
@@ -14,17 +14,11 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class StatusMessageResponseDto {
-    private Member erranderNo; // 심부름 꾼
-
-    private Errand errandNo; // 심부름 번호
-
     private String contents; // 현황 정보
 
     private LocalDateTime created;
 
     public StatusMessageResponseDto(StatusMessage statusMessage) {
-        this.erranderNo = statusMessage.getErranderNo();
-        this.errandNo = statusMessage.getErrandNo();
         this.contents = statusMessage.getContents();
         this.created = statusMessage.getCreated();
     }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/repository/StatusMessageRepository.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/repository/StatusMessageRepository.java
@@ -1,8 +1,12 @@
 package com.pknuErrand.appteam.repository;
 
 
+import com.pknuErrand.appteam.domain.errand.Errand;
 import com.pknuErrand.appteam.domain.statusMessage.StatusMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StatusMessageRepository extends JpaRepository<StatusMessage, Long> {
+    List<StatusMessage> findByErrandNo(Errand errandNo);
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/statusMessage/StatusMessageService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/statusMessage/StatusMessageService.java
@@ -5,11 +5,16 @@ import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.domain.statusMessage.StatusMessage;
 import com.pknuErrand.appteam.dto.statusMessage.StatusMessageRequestDto;
 import com.pknuErrand.appteam.dto.statusMessage.StatusMessageResponseDto;
+import com.pknuErrand.appteam.exception.CustomException;
+import com.pknuErrand.appteam.exception.ErrorCode;
 import com.pknuErrand.appteam.repository.StatusMessageRepository;
 import com.pknuErrand.appteam.service.errand.ErrandService;
 import com.pknuErrand.appteam.service.member.MemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
@@ -24,9 +29,9 @@ public class StatusMessageService {
         this.memberService = memberService;
         this.errandService = errandService;
     }
-    public StatusMessage saveStatusMessage(StatusMessageRequestDto statusMessageRequestDto) {
+    public StatusMessage saveStatusMessage(StatusMessageRequestDto statusMessageRequestDto, Long errandNo) {
         Member errander = memberService.findMemberByMemberNo(statusMessageRequestDto.getErranderNo());
-        Errand errand = errandService.findErrandById(statusMessageRequestDto.getErrandNo());
+        Errand errand = errandService.findErrandById(errandNo);
         StatusMessage message = StatusMessage.builder()
                 .erranderNo(errander)
                 .errandNo(errand)
@@ -34,5 +39,18 @@ public class StatusMessageService {
                 .build();
         statusMessageRepository.save(message);
         return message;
+    }
+
+    public List<StatusMessageResponseDto> getStatusMessageList(Long errandNo) {
+        Errand errand = errandService.findErrandById(errandNo);
+        if(!memberService.getLoginMember().equals(errand.getErranderNo()) && !memberService.getLoginMember().equals(errand.getOrderNo()))
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        List<StatusMessage> list = statusMessageRepository.findByErrandNo(errand);
+        List<StatusMessageResponseDto> filteredStatusMessageList = new ArrayList<>();
+        for(StatusMessage message : list) {
+            StatusMessageResponseDto filteredStatusMessage = new StatusMessageResponseDto(message);
+            filteredStatusMessageList.add(filteredStatusMessage);
+        }
+        return filteredStatusMessageList;
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #136 

### 📝 주요 작업 내용

- WebSocket 메시지 전달 시 StatusMessageResponseDto 필드 축소
  - 기존 Member, Errand 객체 전체가 전달됐으나, 메시지 정보와 메시지 전송 시간만 보내는걸로 변경
- 현황페이지 재 접속 시 기존 메시지를 불러오는 기능 추가
  - StatusMessageResponseDto의 List를 응답
  - 해당 심부름이 요청한 사용자와 관계없는 심부름이라면 401 UNAUTHORIZED 반환
- StatusMessageRequestDto 필드에 errandNo 제거
  - DestinationVariable로 errandNo 값을 받기 때문에 중복으로 받지 않도록 수정
