### PR TITLE
feature/138 심부름 완료 관련 api

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -149,7 +149,6 @@ public class ErrandController {
                 .body(list);
     }
 
-
     @GetMapping("/all")
     public ResponseEntity<List<ErrandListResponseDto>> getAllErrand() {
         List<ErrandListResponseDto> errandListResponseDto = errandService.findAllErrand();

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -126,28 +126,6 @@ public class ErrandController {
         return ResponseEntity.ok().build();
     }
 
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "진행중인 심부름 있음") ,
-            @ApiResponse(responseCode = "404", description = "진행중인 심부름 없음") ,
-    })
-    @Operation(summary = "사용자의 진행중인 심부름 여부 확인")
-    @GetMapping("/in-progress/exist")
-    public ResponseEntity<Void> checkInProgressErrandExist() {
-        errandService.checkInProgressErrandExist();
-        return ResponseEntity.ok().build();
-    }
-
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "진행중인 심부름 있음", content = @Content(schema = @Schema(implementation = InProgressErrandListResponseDto.class))) ,
-            @ApiResponse(responseCode = "404", description = "진행중인 심부름 없음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
-    })
-    @Operation(summary = "사용자의 진행중인 심부름 불러오기")
-    @GetMapping("/in-progress")
-    public ResponseEntity<List<InProgressErrandListResponseDto>> getInProgressErrand() {
-        List<InProgressErrandListResponseDto> list = errandService.getInProgressErrand();
-        return ResponseEntity.ok()
-                .body(list);
-    }
 
     @GetMapping("/all")
     public ResponseEntity<List<ErrandListResponseDto>> getAllErrand() {

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/statusMessage/StatusMessageController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/statusMessage/StatusMessageController.java
@@ -6,6 +6,7 @@ import com.pknuErrand.appteam.dto.errand.getDto.ErrandDetailResponseDto;
 import com.pknuErrand.appteam.dto.statusMessage.StatusMessageRequestDto;
 import com.pknuErrand.appteam.dto.statusMessage.StatusMessageResponseDto;
 import com.pknuErrand.appteam.exception.ExceptionResponseDto;
+import com.pknuErrand.appteam.service.errand.ErrandService;
 import com.pknuErrand.appteam.service.statusMessage.StatusMessageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -30,6 +31,7 @@ import java.util.List;
 public class StatusMessageController {
 
     private final StatusMessageService statusMessageService;
+
     public StatusMessageController(StatusMessageService statusMessageService) {
         this.statusMessageService = statusMessageService;
     }
@@ -43,13 +45,36 @@ public class StatusMessageController {
     }
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "불러오기 성공", content = @Content(schema = @Schema(implementation = StatusMessageResponseDto.class))) ,
-            @ApiResponse(responseCode = "401\nUNAUTHORIZED_ACCESS", description = "권한이 없는 사용자", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+            @ApiResponse(responseCode = "200", description = "불러오기 성공", content = @Content(schema = @Schema(implementation = StatusMessageResponseDto.class))),
+            @ApiResponse(responseCode = "401\nUNAUTHORIZED_ACCESS", description = "권한이 없는 사용자", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
     })
-    @Operation(summary = "현황페이지 메시지내역 불러오기" , description = "웹소켓 연결 전 불러와야함")
+    @Operation(summary = "현황페이지 메시지내역 불러오기", description = "웹소켓 연결 전 불러와야함")
     @GetMapping("/statusMessage/{errandNo}")
     public ResponseEntity<List<StatusMessageResponseDto>> getStatusMessageList(@PathVariable Long errandNo) {
         return ResponseEntity.ok()
                 .body(statusMessageService.getStatusMessageList(errandNo));
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "errander 완료처리 성공"),
+            @ApiResponse(responseCode = "401\nUNAUTHORIZED_ACCESS", description = "사용자가 errander가 아님", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+    })
+    @Operation(summary = "errander 심부름 완료처리", description = "order 심부름 완료처리 이전에 수행되어야함")
+    @GetMapping("/{errandNo}/complete/errander")
+    public ResponseEntity<Void> erranderCompletionConfirm(@PathVariable Long errandNo) {
+        statusMessageService.erranderCompletionConfirm(errandNo);
+        return ResponseEntity.ok().build();
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "order 완료처리 및 심부름 완료처리 성공"),
+            @ApiResponse(responseCode = "401\nUNAUTHORIZED_ACCESS", description = "사용자가 errander가 아님", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+            @ApiResponse(responseCode = "406\nRESTRICT_CONTENT_ACCESS", description = "Errander가 완료처리하지 않았음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+    })
+    @Operation(summary = "order 심부름 완료처리", description = "errander 심부름 완료처리 이후에 수행되어야함. 자동으로 errand 상태도 DONE으로 변경")
+    @GetMapping("/{errandNo}/complete/order")
+    public ResponseEntity<Void> orderCompletionConfirm(@PathVariable Long errandNo) {
+        statusMessageService.orderCompletionConfirm(errandNo);
+        return ResponseEntity.ok().build();
     }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/statusMessage/StatusMessageController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/statusMessage/StatusMessageController.java
@@ -3,6 +3,7 @@ package com.pknuErrand.appteam.controller.statusMessage;
 
 import com.pknuErrand.appteam.domain.statusMessage.StatusMessage;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandDetailResponseDto;
+import com.pknuErrand.appteam.dto.errand.getDto.InProgressErrandListResponseDto;
 import com.pknuErrand.appteam.dto.statusMessage.StatusMessageRequestDto;
 import com.pknuErrand.appteam.dto.statusMessage.StatusMessageResponseDto;
 import com.pknuErrand.appteam.exception.ExceptionResponseDto;
@@ -55,6 +56,30 @@ public class StatusMessageController {
                 .body(statusMessageService.getStatusMessageList(errandNo));
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "진행중인 심부름 있음") ,
+            @ApiResponse(responseCode = "404", description = "진행중인 심부름 없음") ,
+    })
+    @Operation(summary = "사용자의 진행중인 심부름 여부 확인")
+    @GetMapping("/errand/in-progress/exist")
+    public ResponseEntity<Void> checkInProgressErrandExist() {
+        statusMessageService.checkInProgressErrandExist();
+        return ResponseEntity.ok().build();
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "진행중인 심부름 있음", content = @Content(schema = @Schema(implementation = InProgressErrandListResponseDto.class))) ,
+            @ApiResponse(responseCode = "404", description = "진행중인 심부름 없음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
+    })
+    @Operation(summary = "사용자의 진행중인 심부름 불러오기")
+    @GetMapping("/errand/in-progress")
+    public ResponseEntity<List<InProgressErrandListResponseDto>> getInProgressErrand() {
+        List<InProgressErrandListResponseDto> list = statusMessageService.getInProgressErrand();
+        return ResponseEntity.ok()
+                .body(list);
+    }
+
+    
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "errander 완료처리 성공"),
             @ApiResponse(responseCode = "401\nUNAUTHORIZED_ACCESS", description = "사용자가 errander가 아님", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/Errand.java
@@ -58,6 +58,10 @@ public class Errand {
     @JoinColumn
     private Member erranderNo; // 심부름꾼
 
+    @OneToOne
+    @JoinColumn
+    private ErrandCompletionStatus errandCompletionStatus;
+
     public void changeErrandStatusAndSetErrander(Status status, Member errander) {
         this.status = status;
         erranderNo = errander;
@@ -91,5 +95,6 @@ public class Errand {
         this.isCash = isCash;
         this.status = status;
         this.erranderNo = erranderNo;
+        this.errandCompletionStatus = new ErrandCompletionStatus(this);
     }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/ErrandCompletionStatus.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/domain/errand/ErrandCompletionStatus.java
@@ -1,0 +1,42 @@
+package com.pknuErrand.appteam.domain.errand;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class ErrandCompletionStatus {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(mappedBy = "errandCompletionStatus")
+    @JoinColumn
+    private Errand errand;
+
+    @Column(nullable = false)
+    private boolean orderConfirmed;
+
+    @Column(nullable = false)
+    private boolean erranderConfirmed;
+
+    public ErrandCompletionStatus(Errand errand) {
+        this.errand = errand;
+        orderConfirmed = false;
+        erranderConfirmed = false;
+    }
+
+    public void setErranderConfirmed(boolean flag) {
+        erranderConfirmed = flag;
+    }
+
+    public void setOrderConfirmed(boolean flag){
+        orderConfirmed = flag;
+    }
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandCompletionStatusRepository.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandCompletionStatusRepository.java
@@ -1,0 +1,8 @@
+package com.pknuErrand.appteam.repository.errand;
+
+import com.pknuErrand.appteam.domain.errand.Errand;
+import com.pknuErrand.appteam.domain.errand.ErrandCompletionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ErrandCompletionStatusRepository extends JpaRepository<ErrandCompletionStatus, Long> {
+}

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -224,33 +224,4 @@ public class ErrandService {
         }
         errandRepository.delete(errand);
     }
-
-    @Transactional
-    public void checkInProgressErrandExist() {
-        Member member = memberService.getLoginMember();
-        List<Errand> inProgressErrandList = errandRepository.findInProgressErrand(member.getMemberNo());
-        if(inProgressErrandList.size() == 0)
-            throw new CustomException(ErrorCode.ERRAND_NOT_FOUND);
-//        for(Errand errand: inProgressErrandList)
-//            System.out.println(errand.getErrandNo());
-    }
-
-    @Transactional
-    public List<InProgressErrandListResponseDto> getInProgressErrand() {
-        Member member = memberService.getLoginMember();
-        List<Errand> inProgressErrandList = errandRepository.findInProgressErrand(member.getMemberNo());
-        if(inProgressErrandList.size() == 0)
-            throw new CustomException(ErrorCode.ERRAND_NOT_FOUND);
-        List<InProgressErrandListResponseDto> filteredinProgressErrandList = new ArrayList<>();
-        for(Errand errand : inProgressErrandList) {
-            InProgressErrandListResponseDto filteredErrand = InProgressErrandListResponseDto.builder()
-                    .errandNo(errand.getErrandNo())
-                    .title(errand.getTitle())
-                    .due(errand.getDue())
-                    .isUserOrder(errand.getOrderNo().equals(member))
-                    .build();
-            filteredinProgressErrandList.add(filteredErrand);
-        }
-        return filteredinProgressErrandList;
-    }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -3,6 +3,7 @@ package com.pknuErrand.appteam.service.errand;
 import com.pknuErrand.appteam.domain.errand.Errand;
 import com.pknuErrand.appteam.domain.errand.ErrandBuilder;
 import com.pknuErrand.appteam.Enum.Status;
+import com.pknuErrand.appteam.domain.errand.ErrandCompletionStatus;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandListResponseDto;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandDetailResponseDto;
 import com.pknuErrand.appteam.dto.errand.getDto.ErrandPaginationRequestVo;
@@ -12,6 +13,7 @@ import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.dto.member.MemberErrandDto;
 import com.pknuErrand.appteam.exception.CustomException;
 import com.pknuErrand.appteam.exception.ErrorCode;
+import com.pknuErrand.appteam.repository.errand.ErrandCompletionStatusRepository;
 import com.pknuErrand.appteam.repository.errand.ErrandRepository;
 import com.pknuErrand.appteam.service.member.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,11 +29,13 @@ import static com.pknuErrand.appteam.Enum.Status.RECRUITING;
 public class ErrandService {
 
     private final ErrandRepository errandRepository;
+    private final ErrandCompletionStatusRepository errandCompletionStatusRepository;
     private final MemberService memberService;
 
     @Autowired
-    ErrandService(ErrandRepository errandRepository, MemberService memberService) {
+    ErrandService(ErrandRepository errandRepository, MemberService memberService, ErrandCompletionStatusRepository errandCompletionStatusRepository) {
         this.errandRepository = errandRepository;
+        this.errandCompletionStatusRepository = errandCompletionStatusRepository;
         this.memberService = memberService;
     }
 
@@ -54,6 +58,7 @@ public class ErrandService {
                 .status(RECRUITING)
                 .erranderNo(null)
                 .build();
+        errandCompletionStatusRepository.save(saveErrand.getErrandCompletionStatus());
         errandRepository.save(saveErrand);
         return findErrandDetailById(saveErrand.getErrandNo());
     }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/statusMessage/StatusMessageService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/statusMessage/StatusMessageService.java
@@ -1,6 +1,8 @@
 package com.pknuErrand.appteam.service.statusMessage;
 
+import com.pknuErrand.appteam.Enum.Status;
 import com.pknuErrand.appteam.domain.errand.Errand;
+import com.pknuErrand.appteam.domain.errand.ErrandCompletionStatus;
 import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.domain.statusMessage.StatusMessage;
 import com.pknuErrand.appteam.dto.statusMessage.StatusMessageRequestDto;
@@ -8,6 +10,7 @@ import com.pknuErrand.appteam.dto.statusMessage.StatusMessageResponseDto;
 import com.pknuErrand.appteam.exception.CustomException;
 import com.pknuErrand.appteam.exception.ErrorCode;
 import com.pknuErrand.appteam.repository.StatusMessageRepository;
+import com.pknuErrand.appteam.repository.errand.ErrandCompletionStatusRepository;
 import com.pknuErrand.appteam.service.errand.ErrandService;
 import com.pknuErrand.appteam.service.member.MemberService;
 import org.springframework.stereotype.Service;
@@ -20,14 +23,17 @@ import java.util.List;
 @Transactional
 public class StatusMessageService {
     private final StatusMessageRepository statusMessageRepository;
+    private final ErrandCompletionStatusRepository errandCompletionStatusRepository;
     private final MemberService memberService;
     private final ErrandService errandService;
     public StatusMessageService(StatusMessageRepository statusMessageRepository,
+                                ErrandCompletionStatusRepository errandCompletionStatusRepository,
                                 MemberService memberService,
                                 ErrandService errandService) {
         this.statusMessageRepository = statusMessageRepository;
         this.memberService = memberService;
         this.errandService = errandService;
+        this.errandCompletionStatusRepository = errandCompletionStatusRepository;
     }
     public StatusMessage saveStatusMessage(StatusMessageRequestDto statusMessageRequestDto, Long errandNo) {
         Member errander = memberService.findMemberByMemberNo(statusMessageRequestDto.getErranderNo());
@@ -52,5 +58,25 @@ public class StatusMessageService {
             filteredStatusMessageList.add(filteredStatusMessage);
         }
         return filteredStatusMessageList;
+    }
+
+    public void erranderCompletionConfirm(Long errandNo) {
+        Member errander = memberService.getLoginMember();
+        Errand errand = errandService.findErrandById(errandNo);
+        if(!errand.getErranderNo().equals(errander))
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS, "요청한 사용자가 Errander가 아닙니다.");
+        errand.getErrandCompletionStatus().setErranderConfirmed(true);
+    }
+
+    public void orderCompletionConfirm(Long errandNo) {
+        Member order = memberService.getLoginMember();
+        Errand errand = errandService.findErrandById(errandNo);
+        if(!errand.getOrderNo().equals(order))
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS, "요청한 사용자가 Order가 아닙니다.");
+        ErrandCompletionStatus errandCompletionStatus = errand.getErrandCompletionStatus();
+        if(!errandCompletionStatus.isErranderConfirmed())
+            throw new CustomException(ErrorCode.RESTRICT_CONTENT_ACCESS, "아직 Errander가 완료처리하지 않았습니다.");
+        errandCompletionStatus.setOrderConfirmed(true);
+        errandService.changeErrandStatusAndSetErrander(errand, Status.DONE, errand.getErranderNo());
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #138 

### 📝 주요 작업 내용

- 심부름 완료 처리 테이블 추가
  - 스키마 다음과 같음
  - OneToOne 관계, 연관관계 주인 : Errand 테이블
  
![image](https://github.com/pknu-wap/2024-1_App1/assets/144558971/7035d2cc-ee1d-4411-b860-01ce15053173)

- Errander 완료처리 api
  - 데이터베이스의 해당 심부름 erranderConfirm 값을 true로 변경
  - Method : GET / EndPoint : /{errandNo}/complete/errander
  - HTTP CODE / ERROR CODE
     - 성공적으로 처리 : 200
     - 요청한 사용자가 해당 심부름의 errander가 아닐경우 : 401 / UNAUTHORIZED_ACCESS

- Order 완료처리 및 심부름 상태 DONE으로 변경 api
  - 데이터베이스의 해당 심부름 orderConfirm 값을 true로 변경하고 심부름 상태 DONE으로 변경
  - Method : GET / EndPoint : /{errandNo}/complete/order
  - HTTP CODE / ERROR CODE
     - 성공적으로 처리 : 200
     - 요청한 사용자가 해당 심부름의 order가 아닐경우 : 401 / UNAUTHORIZED_ACCESS
     - Errander가 아직 완료처리하기 이전인 경우 : 406 / RESTRICT_CONTENT_ACCESS

- 현황페이지로 연결하기위한 모든 api를 StatusMessageController로 이동

