### PR TITLE
feature/153 요청서 수락하기 api response 값 변경

### DIFF
--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -12,6 +12,7 @@ import com.pknuErrand.appteam.service.errand.ErrandService;
 import com.pknuErrand.appteam.service.member.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Tag(name = "Errand", description = "Errand 관련 API")
@@ -88,14 +90,17 @@ public class ErrandController {
     }
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "수락 성공", content = @Content(schema = @Schema(implementation = ErrandDetailResponseDto.class))) ,
+            @ApiResponse(responseCode = "200", description = "수락 성공", content = @Content(examples = {
+                    @ExampleObject(
+                            value = "{ \"name\": \"김수현\", \"nickname\": \"한상차림위샹체쯔\" }")
+            })) ,
             @ApiResponse(responseCode = "404\nERRAND_NOT_FOUND", description = "심부름 찾을 수 없음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
             @ApiResponse(responseCode = "401\nUNAUTHORIZED_ACCESS", description = "본인 게시물 수락할 수 없음", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
             @ApiResponse(responseCode = "406\nRESTRICT_CONTENT_ACCESS", description = "진행중/완료 상태인 심부름 수락 불가능", content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))) ,
     })
     @Operation(summary = "요청서 수락하기", description = "요청서 수락요청을 통해 errand status 변경하기")
     @GetMapping("/{id}/accept")
-    public ResponseEntity<ErrandDetailResponseDto> acceptErrand(@PathVariable Long id) {
+    public ResponseEntity<Map<String, String>> acceptErrand(@PathVariable Long id) {
         return ResponseEntity.ok()
                 .body(errandService.acceptErrand(id));
     }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -21,7 +21,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.pknuErrand.appteam.Enum.Status.RECRUITING;
 
@@ -167,7 +169,7 @@ public class ErrandService {
     }
 
     @Transactional
-    public ErrandDetailResponseDto acceptErrand(Long id) {
+    public Map<String, String> acceptErrand(Long id) {
         Errand errand = errandRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.ERRAND_NOT_FOUND));
         Member errander = memberService.getLoginMember();
         /** 본인 게시물이라면 예외 발생 **/
@@ -177,7 +179,11 @@ public class ErrandService {
             throw new CustomException(ErrorCode.RESTRICT_CONTENT_ACCESS, "진행중이거나 완료된 심부름은 수락이 불가능합니다.");
         }
         changeErrandStatusAndSetErrander(errand, Status.IN_PROGRESS, errander);
-        return findErrandDetailById(id);
+
+        Map<String, String> responseMap = new HashMap<>();
+        responseMap.put("nickname", errander.getName());
+        responseMap.put("name", errander.getNickname());
+        return responseMap;
     }
 
     @Transactional


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #153 

### 📝 주요 작업 내용

- acceptErrand return 타입 변경 (요청서 수락하기 api 응답 데이터 변경)
  - 기존 : 수락 성공시 200 ok + ErrandDetailResponseDto
  - 변경 : 수락 성공시 200 ok + Map<String, String>
- 예시
```json
{
  "name": "김수현",
  "nickname": "한상차림위샹체쯔"
}
```

수락하기 요청 성공 후 프론트에서 수락한 사용자 본인의 name, nickname 데이터 필요
