### PR TITLE
feature/158 요청서 등록 페이지 api 연동

### DIFF
--- a/client/.idea/workspace.xml
+++ b/client/.idea/workspace.xml
@@ -6,8 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="5b21be5b-2c8c-4bd1-b7ab-c208ec551126" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/front/lib/map.dart" beforeDir="false" afterPath="$PROJECT_DIR$/front/lib/map.dart" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/front/lib/request.dart" beforeDir="false" afterPath="$PROJECT_DIR$/front/lib/request.dart" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/front/lib/upload_image.dart" beforeDir="false" afterPath="$PROJECT_DIR$/front/lib/upload_image.dart" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -45,30 +45,30 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ASKED_ADD_EXTERNAL_FILES": "true",
-    "Flutter.main_act.executor": "Run",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.cidr.known.project.marker": "true",
-    "RunOnceActivity.readMode.enableVisualFormatting": "true",
-    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "cf.first.check.clang-format": "false",
-    "cidr.known.project.marker": "true",
-    "com.android.tools.idea.streaming.zoom.toolbar.visible": "false",
-    "dart.analysis.tool.window.visible": "false",
-    "git-widget-placeholder": "develop-FE",
-    "io.flutter.reload.alreadyRun": "true",
-    "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "C:/flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk",
-    "project.structure.last.edited": "Modules",
-    "project.structure.proportion": "0.15",
-    "project.structure.side.proportion": "0.2",
-    "settings.editor.selected.configurable": "dart.settings",
-    "show.migrate.to.gradle.popup": "false"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_ADD_EXTERNAL_FILES&quot;: &quot;true&quot;,
+    &quot;Flutter.main_act.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.readMode.enableVisualFormatting&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;cf.first.check.clang-format&quot;: &quot;false&quot;,
+    &quot;cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;com.android.tools.idea.streaming.zoom.toolbar.visible&quot;: &quot;false&quot;,
+    &quot;dart.analysis.tool.window.visible&quot;: &quot;false&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/158-요청서-등록-페이지-api-연동&quot;,
+    &quot;io.flutter.reload.alreadyRun&quot;: &quot;true&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/민경윤/Desktop/논문/주뻬.jpg&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Modules&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;dart.settings&quot;,
+    &quot;show.migrate.to.gradle.popup&quot;: &quot;false&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager" selected="Flutter.main_act">
     <configuration name="main.dart" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application" temporary="true" nameIsGenerated="true">
       <option name="filePath" value="$PROJECT_DIR$/front/lib/main.dart" />

--- a/client/.idea/workspace.xml
+++ b/client/.idea/workspace.xml
@@ -5,9 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="5b21be5b-2c8c-4bd1-b7ab-c208ec551126" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/front/lib/request.dart" beforeDir="false" afterPath="$PROJECT_DIR$/front/lib/request.dart" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/front/lib/upload_image.dart" beforeDir="false" afterPath="$PROJECT_DIR$/front/lib/upload_image.dart" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/client/front/lib/request.dart
+++ b/client/front/lib/request.dart
@@ -40,10 +40,10 @@ class ErrandRequest {
   final String? due;
   final String? detail;
   final int reward;
-  final bool cash;
+  final bool isCash;
   ErrandRequest({required this.createdDate, required this.title, required this.destination,
     required this.latitude, required this.longitude, required this.due, required this.detail,
-    required this.reward, required this.cash});
+    required this.reward, required this.isCash});
 
   Map<String, dynamic> toJson(){
     return {
@@ -55,7 +55,7 @@ class ErrandRequest {
       "due" : due,
       "detail" : detail,
       "reward" : reward,
-      "cash" : cash
+      "isCash" : isCash
     };
   }
 }
@@ -147,7 +147,7 @@ class _RequestState extends State<Request> {
         due: setDue(),
         detail: requestController.text,
         reward: int.parse(priceController.text),
-        cash: isSelected2[1],
+        isCash: isSelected2[1],
     );
     String baseUrl = dotenv.env['BASE_URL'] ?? '';
     String url = "${baseUrl}errand";
@@ -175,10 +175,8 @@ class _RequestState extends State<Request> {
   }
   String setDue() {
     DateTime now = DateTime.now();
-    print(now);
     if(isSelected1[1])
       now = now.add(Duration(days : 1));
-    print(now);
     DateTime due = DateTime(
         now.year,
       now.month,
@@ -186,7 +184,6 @@ class _RequestState extends State<Request> {
       _selectedHour,
       _selectedMinute
     );
-    print(due);
     return due.toString();
   }
 

--- a/client/front/lib/request.dart
+++ b/client/front/lib/request.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:developer';
 
 import 'package:flutter/cupertino.dart';
@@ -5,11 +6,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_naver_map/flutter_naver_map.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:http/http.dart';
 import 'package:intl/intl.dart';
+import 'errand_check.dart';
 import 'map.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+final storage = FlutterSecureStorage();
+
 
 // import 'package:http/http.dart' as http;
 // import 'dart:convert';
@@ -22,6 +30,34 @@ class Request extends StatefulWidget {
   const Request({super.key});
   @override
   _RequestState createState() => _RequestState();
+}
+class ErrandRequest {
+  final String? createdDate;
+  final String? title;
+  final String? destination;
+  final double latitude;
+  final double longitude;
+  final String? due;
+  final String? detail;
+  final int reward;
+  final bool cash;
+  ErrandRequest({required this.createdDate, required this.title, required this.destination,
+    required this.latitude, required this.longitude, required this.due, required this.detail,
+    required this.reward, required this.cash});
+
+  Map<String, dynamic> toJson(){
+    return {
+      "createdDate" : createdDate,
+      "title" : title,
+      "destination" : destination,
+      "latitude" : latitude,
+      "longitude" : longitude,
+      "due" : due,
+      "detail" : detail,
+      "reward" : reward,
+      "cash" : cash
+    };
+  }
 }
 
 class ReturnValues {
@@ -98,6 +134,60 @@ class _RequestState extends State<Request> {
       log("exception: " + e.toString());
       return Future.error("faild Geolocator");
     }
+  }
+  void errandPostRequest() async {
+    log("작성완료 request");
+    late ErrandRequest errand;
+    errand = ErrandRequest(
+        createdDate: DateTime.now().toString(),
+        title: titleController.text,
+        destination: detailAddressController.text,
+        latitude: value.latitude,
+        longitude: value.longitude,
+        due: setDue(),
+        detail: requestController.text,
+        reward: int.parse(priceController.text),
+        cash: isSelected2[1],
+    );
+    String baseUrl = dotenv.env['BASE_URL'] ?? '';
+    String url = "${baseUrl}errand";
+    String? token = await storage.read(key: 'TOKEN');
+    try {
+      var response = await http.post(Uri.parse(url),
+          body: jsonEncode(errand.toJson()),
+          headers: {"Authorization": "$token",
+            "Content-Type": "application/json"
+          });
+      if (response.statusCode == 200) {
+        int errandNo = jsonDecode(response.body)['errandNo'];
+        Navigator.of(context).push(
+            MaterialPageRoute(
+                builder: (context) => MainErrandCheck(errandNo: errandNo)
+            ),);
+      }
+      else {
+        print("ERROR : ");
+        print(jsonDecode(response.body));
+      }
+    } catch(e) {
+      log(e.toString());
+    }
+  }
+  String setDue() {
+    DateTime now = DateTime.now();
+    print(now);
+    if(isSelected1[1])
+      now = now.add(Duration(days : 1));
+    print(now);
+    DateTime due = DateTime(
+        now.year,
+      now.month,
+      now.day,
+      _selectedHour,
+      _selectedMinute
+    );
+    print(due);
+    return due.toString();
   }
 
   @override
@@ -176,6 +266,7 @@ class _RequestState extends State<Request> {
         }
       }
     });
+    //print(isSelected1);
   }
 
   void toggleSelect2(int newindex) {
@@ -951,9 +1042,7 @@ class _RequestState extends State<Request> {
                 margin: EdgeInsets.only(left: 20.0, right: 20.0, top: 50),
                 child: ElevatedButton(
                   onPressed: () {
-                    print("요청서 작성 완료");
-                    DateTime currentTime = DateTime.now();
-                    log(currentTime.toString());
+                    errandPostRequest();
                   },
                   style: ButtonStyle(
                     // 버튼의 배경색 변경하기

--- a/client/front/lib/upload_image.dart
+++ b/client/front/lib/upload_image.dart
@@ -41,6 +41,7 @@ class _Upload_ImageState extends State<Upload_Image> {
   String parsedtext = ''; // 추출된 텍스트를 저장할 String 변수
   late User u1 = User('','','','','','');
 
+
   parsethetext() async {
     final pickedFile = await ImagePicker().pickImage(source: ImageSource.gallery);
     if (pickedFile == null) return;
@@ -50,6 +51,7 @@ class _Upload_ImageState extends State<Upload_Image> {
     var url = 'https://api.ocr.space/parse/image';
     var payload = {"base64Image": "data:image/png;base64,${img64.toString()}","language" :"kor"};
     var header = {"apikey" :"K88159020988957"};
+
 
     var post = await http.post(Uri.parse(url),body: payload,headers: header);
     var result = jsonDecode(post.body); // 추출 결과를 받아서 result에 저장
@@ -84,6 +86,7 @@ class _Upload_ImageState extends State<Upload_Image> {
       splitText.removeAt(0); // 첫 번째 요소인 "남은시간: 30"은 필요 없으므로 제거
 
       // 추출된 텍스트에서 학번, 이름, 전공 추출
+
       if (splitText.length >= 3) {
         setState(() {
           //splitText[0]: 이름, splitText[1]: 전공, splitText[2]: 학번


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #158 

### 📝 주요 작업 내용

- request body 데이터 스키마에 맞는 ErrandRequest 클래스 생성
- 요청서 등록 api 연동 완료
``` flutter
late ErrandRequest errand;
    errand = ErrandRequest(
        createdDate: DateTime.now().toString(),
        title: titleController.text,
        destination: detailAddressController.text,
        latitude: value.latitude,
        longitude: value.longitude,
        due: setDue(),
        detail: requestController.text,
        reward: int.parse(priceController.text),
        isCash: isSelected2[1],
    );
```
``` flutter
String setDue() {
    DateTime now = DateTime.now();
    if(isSelected1[1])
      now = now.add(Duration(days : 1));
    DateTime due = DateTime(
        now.year,
      now.month,
      now.day,
      _selectedHour,
      _selectedMinute
    );
    return due.toString();
  }
```
- 등록 완료 후, 요청서 글 보기 페이지로 Navigator
  - 해당 페이지로 이동 후 뒤로가기 누르면 요청서 등록 직전 상태의 페이지가 나오는 문제가 있음