### PR TITLE
feature/164 회원가입 완료 후 자동 로그인 기능

### DIFF
--- a/client/.idea/workspace.xml
+++ b/client/.idea/workspace.xml
@@ -6,6 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="5b21be5b-2c8c-4bd1-b7ab-c208ec551126" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/front/lib/profile.dart" beforeDir="false" afterPath="$PROJECT_DIR$/front/lib/profile.dart" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/front/lib/sign_up_success.dart" beforeDir="false" afterPath="$PROJECT_DIR$/front/lib/sign_up_success.dart" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/front/lib/upload_image.dart" beforeDir="false" afterPath="$PROJECT_DIR$/front/lib/upload_image.dart" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -44,30 +46,30 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ASKED_ADD_EXTERNAL_FILES": "true",
-    "Flutter.main_act.executor": "Run",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.cidr.known.project.marker": "true",
-    "RunOnceActivity.readMode.enableVisualFormatting": "true",
-    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "cf.first.check.clang-format": "false",
-    "cidr.known.project.marker": "true",
-    "com.android.tools.idea.streaming.zoom.toolbar.visible": "false",
-    "dart.analysis.tool.window.visible": "false",
-    "git-widget-placeholder": "feature/162-학생증-이미지-업로드-중-문제-발생-시-페이지-안-넘어가지는-문제",
-    "io.flutter.reload.alreadyRun": "true",
-    "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "C:/Users/민경윤/Desktop/논문/주뻬.jpg",
-    "project.structure.last.edited": "Modules",
-    "project.structure.proportion": "0.15",
-    "project.structure.side.proportion": "0.2",
-    "settings.editor.selected.configurable": "dart.settings",
-    "show.migrate.to.gradle.popup": "false"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_ADD_EXTERNAL_FILES&quot;: &quot;true&quot;,
+    &quot;Flutter.main_act.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.readMode.enableVisualFormatting&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;cf.first.check.clang-format&quot;: &quot;false&quot;,
+    &quot;cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;com.android.tools.idea.streaming.zoom.toolbar.visible&quot;: &quot;false&quot;,
+    &quot;dart.analysis.tool.window.visible&quot;: &quot;false&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/164-회원가입-완료-후-자동-로그인-기능&quot;,
+    &quot;io.flutter.reload.alreadyRun&quot;: &quot;true&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/민경윤/Desktop/논문/주뻬.jpg&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Modules&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;dart.settings&quot;,
+    &quot;show.migrate.to.gradle.popup&quot;: &quot;false&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager" selected="Flutter.main_act">
     <configuration name="main.dart" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application" temporary="true" nameIsGenerated="true">
       <option name="filePath" value="$PROJECT_DIR$/front/lib/main.dart" />

--- a/client/front/lib/profile.dart
+++ b/client/front/lib/profile.dart
@@ -116,7 +116,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
             Navigator.of(context).push(
               MaterialPageRoute(
                 builder: (BuildContext context) =>
-                    Signup_Success(),
+                    Signup_Success(username : u1.id, pw : u1.pw),
               ),
             );
           } else{

--- a/client/front/lib/upload_image.dart
+++ b/client/front/lib/upload_image.dart
@@ -75,6 +75,7 @@ class _Upload_ImageState extends State<Upload_Image> {
       });
     } catch(e) {
       log("error at picked image or connect OCR api");
+      u1 = User(widget.requestMail,'','','','','');
     }
     finally {
       setState(() {


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #164 

### 📝 주요 작업 내용

- profile.dart -> Signup_Success 로 Nagigator.push 할 때 파라미터로 User u1 객체 안의 id / pw를 받아서 함께 넘겨줌
- Signup_Success -> Confetti 로 넘어갈때도 마찬가지로 id/pw를 넘겨
- 회원가입에 사용된 id/pw를 통해 로그인 api 요청 후 토큰을 local storage에 저장하고, 메인 페이지로 이동

- 학생증 업로드 시 Exception 발생 시 mail 정보가 User 객체에 공백으로 넘어오는 문제 발생
  - #162 
  - 예외 발생 시 그냥 u1 객체를 넘겨주도록 했지만, 코드를 보니 ocr 요청 성공 후, 전 페이지에서 받아온 mail 정보를 그 때서야 u1객체에 넣는것을 확인
  - 예외를 catch했을 때 u1객체에 mail 정보를 추가하고 나머지 부분은 공백으로 유지시키고, finally 블록에서 페이지를 이동시켰음