### PR TITLE
Bug/203/하단바 오버레이 고치기

### DIFF
--- a/client/.idea/libraries/Dart_Packages.xml
+++ b/client/.idea/libraries/Dart_Packages.xml
@@ -19,7 +19,7 @@
         <entry key="archive">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/archive-3.5.1/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/archive-3.6.1/lib" />
             </list>
           </value>
         </entry>
@@ -100,6 +100,13 @@
             </list>
           </value>
         </entry>
+        <entry key="dropdown_button2">
+          <value>
+            <list>
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/dropdown_button2-2.3.9/lib" />
+            </list>
+          </value>
+        </entry>
         <entry key="fake_async">
           <value>
             <list>
@@ -152,7 +159,7 @@
         <entry key="flutter">
           <value>
             <list>
-              <option value="$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/packages/flutter/lib" />
+              <option value="$PROJECT_DIR$/../../../../../../flutter/packages/flutter/lib" />
             </list>
           </value>
         </entry>
@@ -194,7 +201,7 @@
         <entry key="flutter_secure_storage">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage-9.2.1/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage-9.2.2/lib" />
             </list>
           </value>
         </entry>
@@ -208,7 +215,7 @@
         <entry key="flutter_secure_storage_macos">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_macos-3.1.1/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_macos-3.1.2/lib" />
             </list>
           </value>
         </entry>
@@ -243,14 +250,14 @@
         <entry key="flutter_test">
           <value>
             <list>
-              <option value="$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/packages/flutter_test/lib" />
+              <option value="$PROJECT_DIR$/../../../../../../flutter/packages/flutter_test/lib" />
             </list>
           </value>
         </entry>
         <entry key="flutter_web_plugins">
           <value>
             <list>
-              <option value="$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/packages/flutter_web_plugins/lib" />
+              <option value="$PROJECT_DIR$/../../../../../../flutter/packages/flutter_web_plugins/lib" />
             </list>
           </value>
         </entry>
@@ -327,14 +334,14 @@
         <entry key="image">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image-4.1.7/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image-4.2.0/lib" />
             </list>
           </value>
         </entry>
         <entry key="image_picker">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker-1.1.1/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker-1.1.2/lib" />
             </list>
           </value>
         </entry>
@@ -355,7 +362,7 @@
         <entry key="image_picker_ios">
           <value>
             <list>
-              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_ios-0.8.11+2/lib" />
+              <option value="$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_ios-0.8.12/lib" />
             </list>
           </value>
         </entry>
@@ -544,7 +551,7 @@
         <entry key="sky_engine">
           <value>
             <list>
-              <option value="$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/pkg/sky_engine/lib" />
+              <option value="$PROJECT_DIR$/../../../../../../flutter/bin/cache/pkg/sky_engine/lib" />
             </list>
           </value>
         </entry>
@@ -686,7 +693,7 @@
     <CLASSES>
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/animated_text_kit-4.2.2/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/ansicolor-2.0.2/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/archive-3.5.1/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/archive-3.6.1/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/args-2.5.0/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/async-2.11.0/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/boolean_selector-2.1.1/lib" />
@@ -698,6 +705,7 @@
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/crypto-3.0.3/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/csslib-1.0.0/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/cupertino_icons-1.0.8/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/dropdown_button2-2.3.9/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/fake_async-1.3.1/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/ffi-2.1.2/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/file_selector_linux-0.9.2+1/lib" />
@@ -710,9 +718,9 @@
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_native_splash-2.4.0/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_naver_map-1.2.2/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_plugin_android_lifecycle-2.0.19/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage-9.2.1/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage-9.2.2/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_linux-1.2.1/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_macos-3.1.1/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_macos-3.1.2/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_platform_interface-1.1.2/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_web-1.2.1/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_windows-3.1.2/lib" />
@@ -727,11 +735,11 @@
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/html-0.15.4/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/http-0.13.6/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/http_parser-4.0.2/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image-4.1.7/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker-1.1.1/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image-4.2.0/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker-1.1.2/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_android-0.8.12+1/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_for_web-3.0.4/lib" />
-      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_ios-0.8.11+2/lib" />
+      <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_ios-0.8.12/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_linux-0.2.1+1/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_macos-0.2.1+1/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_platform_interface-2.10.0/lib" />
@@ -777,10 +785,10 @@
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/xdg_directories-1.0.4/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/xml-6.5.0/lib" />
       <root url="file://$USER_HOME$/AppData/Local/Pub/Cache/hosted/pub.dev/yaml-3.1.2/lib" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/pkg/sky_engine/lib" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/packages/flutter/lib" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/packages/flutter_test/lib" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/packages/flutter_web_plugins/lib" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/pkg/sky_engine/lib" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/packages/flutter/lib" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/packages/flutter_test/lib" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/packages/flutter_web_plugins/lib" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/client/.idea/libraries/Dart_SDK.xml
+++ b/client/.idea/libraries/Dart_SDK.xml
@@ -1,27 +1,27 @@
 <component name="libraryTable">
   <library name="Dart SDK">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/async" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/cli" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/collection" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/convert" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/core" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/developer" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/ffi" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/html" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/indexed_db" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/io" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/isolate" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/js" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/js_interop" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/js_interop_unsafe" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/js_util" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/math" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/mirrors" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/svg" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/typed_data" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/web_audio" />
-      <root url="file://$PROJECT_DIR$/../../../flutter_windows_3.19.4-stable/flutter/bin/cache/dart-sdk/lib/web_gl" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/async" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/cli" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/collection" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/convert" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/core" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/developer" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/ffi" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/html" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/indexed_db" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/io" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/isolate" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/js" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/js_interop" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/js_interop_unsafe" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/js_util" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/math" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/mirrors" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/svg" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/typed_data" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/web_audio" />
+      <root url="file://$PROJECT_DIR$/../../../../../../flutter/bin/cache/dart-sdk/lib/web_gl" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/client/front/lib/fixerrand/fixerrand.dart
+++ b/client/front/lib/fixerrand/fixerrand.dart
@@ -8,13 +8,122 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../checkerrand.dart';
 import '../writeerrand.dart';
+import '../home.dart';
 import 'fixerrandwidget/fixdue.dart';
 import 'fixerrandwidget/fixiscash.dart';
 import 'fixerrandwidget/fixminimap.dart';
 import 'package:http/http.dart' as http;
 final storage = FlutterSecureStorage();
 
-
+void _insertOverlay(BuildContext context) {
+  if (overlayEntry != null) return;
+  overlayEntry = OverlayEntry(
+    builder: (context) => Positioned(
+      bottom: 0,
+      left: 0,
+      right: 0,
+      child: Container(
+        width: 364,
+        height: 64,
+        decoration: BoxDecoration(
+          color: Color(0xffFFFFFF),
+          border: Border.all(
+            color: Color(0xffCFCFCF),
+            width: 0.5,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Color.fromRGBO(185, 185, 185, 0.25),
+              offset: Offset(5, -1),
+              blurRadius: 5,
+              spreadRadius: 1,
+            ),
+          ],
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Container(
+              width: 22,
+              height: 22,
+              margin: const EdgeInsets.only(left: 44, top: 20.0, bottom: 17.32),
+              child: IconButton(
+                style: IconButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: EdgeInsets.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () {},
+                icon: Image.asset(
+                  'assets/images/home_icon.png',
+                  color: Color(0xffADADAD),
+                ),
+              ),
+            ),
+            Container(
+              width: 19.31,
+              height: 23.81,
+              margin: const EdgeInsets.only(top: 20.0, bottom: 17.32),
+              child: IconButton(
+                style: IconButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: EdgeInsets.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () {},
+                icon: Image.asset(
+                  'assets/images/human_icon.png',
+                  color: Color(0xffADADAD),
+                ),
+              ),
+            ),
+            Container(
+              width: 22.0,
+              height: 22,
+              margin: const EdgeInsets.only(top: 20.0, bottom: 17.32),
+              child: IconButton(
+                style: IconButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: EdgeInsets.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (BuildContext context) => WriteErrand(),
+                    ),
+                  );
+                },
+                icon: Image.asset(
+                  'assets/images/add_icon.png',
+                  color: Color(0xffADADAD),
+                ),
+              ),
+            ),
+            Container(
+              width: 21.95,
+              height: 24.21,
+              margin: const EdgeInsets.only(top: 20.0, bottom: 17.32, right: 43.92),
+              child: IconButton(
+                style: IconButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: EdgeInsets.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () {},
+                icon: Image.asset(
+                  'assets/images/history_icon.png',
+                  color: Color(0xffADADAD),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  Overlay.of(context).insert(overlayEntry!);
+}
 class FixErrand extends StatefulWidget {
   final Map<String, dynamic> errands;
 
@@ -55,6 +164,7 @@ class _FixErrandState extends State<FixErrand> {
             "Content-Type": "application/json"
           });
       if (response.statusCode == 200) {
+        _insertOverlay(context);
         Navigator.of(context).push(
           MaterialPageRoute(
               builder: (context) => MainErrandCheck(errandNo: errandNo,)
@@ -154,6 +264,12 @@ class _FixErrandState extends State<FixErrand> {
   void initState() {
     // 위젯의 초기 상태 설정 = 상태 변화 감지
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (overlayEntry != null) {
+        overlayEntry!.remove();
+        overlayEntry = null;
+      }
+    });
     String decodedTitle = utf8.decode(widget.errands['title'].runes.toList());
     String decodedDetailAddress = utf8.decode(widget.errands['destination'].runes.toList());
     String decodedRequest = utf8.decode(widget.errands['detail'].runes.toList());
@@ -217,7 +333,16 @@ class _FixErrandState extends State<FixErrand> {
 
     @override
     Widget build(BuildContext context) {
-      return Scaffold(
+      return PopScope(
+          canPop: true,
+          onPopInvoked: (bool didPop) async {
+        if (didPop) {
+          _insertOverlay(context);
+          return;
+        }
+        Navigator.of(context).pop();
+      },
+      child: Scaffold(
         body: Container(
           child: SingleChildScrollView(
             child: Column(
@@ -364,8 +489,8 @@ class _FixErrandState extends State<FixErrand> {
                 ),
                 // 일정
                 FixDue(due: due,
-                  setDayParentState: setDayAtChildWidget,
-                  setHourParentState: setHourAtChildWidget,
+                    setDayParentState: setDayAtChildWidget,
+                    setHourParentState: setHourAtChildWidget,
                     setMinuteParentState: setMinuteAtChildWidget),
                 // 도착지 텍스트
                 Container(
@@ -702,6 +827,7 @@ class _FixErrandState extends State<FixErrand> {
             ),
           ),
         ),
+      ),
       );
     }
   }

--- a/client/front/lib/home.dart
+++ b/client/front/lib/home.dart
@@ -1443,7 +1443,7 @@ class _HomeState extends State<Home> {
                                             ? Center(
                                             child: Text("진행중인 심부름이 없습니다."))
                                             : ListView.builder(
-                                          padding: EdgeInsets.only(top: 23.98),
+                                          padding: EdgeInsets.only(top: 23.98, bottom: 50),
                                           itemCount: errands.length,
                                           itemBuilder: (context, index) {
                                             String decodedTitle = utf8.decode(

--- a/client/front/lib/status_page_requesting.dart
+++ b/client/front/lib/status_page_requesting.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:stomp_dart_client/stomp_dart_client.dart';
 
+
 import 'home.dart';
 
 final storage = FlutterSecureStorage();

--- a/client/front/lib/status_page_running.dart
+++ b/client/front/lib/status_page_running.dart
@@ -820,7 +820,7 @@ class _statuspageRState extends State<statuspageR> with TickerProviderStateMixin
                           child: DropdownButton2<String>(
                             hint: Row(
                               children: [
-                                Container( margin: EdgeInsets.only(left: 14.51),
+                                Container( 
                                   child:  Image.asset(
                                     'assets/images/paper-plane.png',
                                     color: Color(0xffADADAD),
@@ -839,8 +839,6 @@ class _statuspageRState extends State<statuspageR> with TickerProviderStateMixin
                                 ),
                               ],
                             ),
-                            // icon: null,
-                            // dropdownColor: Color(0xffFFFFFF), // 드롭다운 배경색
                             items: [
                               customDropdownItem("출발했어요."),
                               customDropdownItem("지금 물건을 픽업했어요."),
@@ -855,6 +853,9 @@ class _statuspageRState extends State<statuspageR> with TickerProviderStateMixin
                             },
                             dropdownStyleData: DropdownStyleData(
                               offset: Offset(0, 350),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(10),
+                              )
                             ),
                             selectedItemBuilder: (BuildContext context) {
                               return [

--- a/client/front/lib/status_page_running.dart
+++ b/client/front/lib/status_page_running.dart
@@ -8,7 +8,7 @@ import 'package:flutter/widgets.dart';
 import 'home.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:stomp_dart_client/stomp_dart_client.dart';
-
+import 'package:dropdown_button2/dropdown_button2.dart';
 final storage = FlutterSecureStorage();
 class StatusContent{//진행중인 심부름이 간략하게 담고 있는 정보들
   String contents; //메시지
@@ -823,7 +823,7 @@ class _statuspageRState extends State<statuspageR> with TickerProviderStateMixin
                           ),
                         ),
                         child: DropdownButtonHideUnderline(
-                          child: DropdownButton<String>(
+                          child: DropdownButton2<String>(
                             hint: Row(
                               children: [
                                 Container( margin: EdgeInsets.only(left: 14.51),
@@ -845,8 +845,8 @@ class _statuspageRState extends State<statuspageR> with TickerProviderStateMixin
                                 ),
                               ],
                             ),
-                            icon: null,
-                            dropdownColor: Color(0xffFFFFFF), // 드롭다운 배경색
+                            // icon: null,
+                            // dropdownColor: Color(0xffFFFFFF), // 드롭다운 배경색
                             items: [
                               customDropdownItem("출발했어요."),
                               customDropdownItem("지금 물건을 픽업했어요."),
@@ -859,6 +859,9 @@ class _statuspageRState extends State<statuspageR> with TickerProviderStateMixin
                             onChanged: (String? value) {
                               sendValue(value);
                             },
+                            dropdownStyleData: DropdownStyleData(
+                              offset: Offset(0, 350),
+                            ),
                             selectedItemBuilder: (BuildContext context) {
                               return [
                                 "출발했어요.",
@@ -884,6 +887,8 @@ class _statuspageRState extends State<statuspageR> with TickerProviderStateMixin
                                 );
                               }).toList();
                             },
+
+
                           ),
                         ),
                       ),

--- a/client/front/lib/status_page_running.dart
+++ b/client/front/lib/status_page_running.dart
@@ -657,12 +657,6 @@ class _statuspageRState extends State<statuspageR> with TickerProviderStateMixin
   void initState()
   {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (overlayEntry != null) {
-        overlayEntry!.remove();
-        overlayEntry = null;
-      }
-    });
     errandNo = widget.errandNo;
     connectNo = errandNo.toString();
     statusMessageInit();
@@ -765,7 +759,7 @@ class _statuspageRState extends State<statuspageR> with TickerProviderStateMixin
                   ],
                 ),
               ),
-              Flexible(child: Container(width: 320, height: 503,
+              Flexible(child: Container(width: 320, height: 422,
                 margin: EdgeInsets.only(left: 20, top: 21.21),
                 decoration: BoxDecoration(
                   color: Color(0xffFFFFFF),

--- a/client/front/lib/writeerrand.dart
+++ b/client/front/lib/writeerrand.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:developer';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -11,12 +10,119 @@ import 'package:flutter_naver_map/flutter_naver_map.dart';
 import 'package:geolocator/geolocator.dart';
 import '../map.dart';
 import 'package:http/http.dart' as http;
-
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-
 import 'checkerrand.dart';
+import 'home.dart';
 final storage = FlutterSecureStorage();
-
+void _insertOverlay(BuildContext context) {
+  if (overlayEntry != null) return;
+  overlayEntry = OverlayEntry(
+    builder: (context) => Positioned(
+      bottom: 0,
+      left: 0,
+      right: 0,
+      child: Container(
+        width: 364,
+        height: 64,
+        decoration: BoxDecoration(
+          color: Color(0xffFFFFFF),
+          border: Border.all(
+            color: Color(0xffCFCFCF),
+            width: 0.5,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Color.fromRGBO(185, 185, 185, 0.25),
+              offset: Offset(5, -1),
+              blurRadius: 5,
+              spreadRadius: 1,
+            ),
+          ],
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Container(
+              width: 22,
+              height: 22,
+              margin: const EdgeInsets.only(left: 44, top: 20.0, bottom: 17.32),
+              child: IconButton(
+                style: IconButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: EdgeInsets.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () {},
+                icon: Image.asset(
+                  'assets/images/home_icon.png',
+                  color: Color(0xffADADAD),
+                ),
+              ),
+            ),
+            Container(
+              width: 19.31,
+              height: 23.81,
+              margin: const EdgeInsets.only(top: 20.0, bottom: 17.32),
+              child: IconButton(
+                style: IconButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: EdgeInsets.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () {},
+                icon: Image.asset(
+                  'assets/images/human_icon.png',
+                  color: Color(0xffADADAD),
+                ),
+              ),
+            ),
+            Container(
+              width: 22.0,
+              height: 22,
+              margin: const EdgeInsets.only(top: 20.0, bottom: 17.32),
+              child: IconButton(
+                style: IconButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: EdgeInsets.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (BuildContext context) => WriteErrand(),
+                    ),
+                  );
+                },
+                icon: Image.asset(
+                  'assets/images/add_icon.png',
+                  color: Color(0xffADADAD),
+                ),
+              ),
+            ),
+            Container(
+              width: 21.95,
+              height: 24.21,
+              margin: const EdgeInsets.only(top: 20.0, bottom: 17.32, right: 43.92),
+              child: IconButton(
+                style: IconButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: EdgeInsets.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () {},
+                icon: Image.asset(
+                  'assets/images/history_icon.png',
+                  color: Color(0xffADADAD),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  Overlay.of(context).insert(overlayEntry!);
+}
 //현재 화면에서 뒤로가기
 class WriteErrand extends StatefulWidget {
   WriteErrand({super.key});
@@ -154,6 +260,7 @@ class _WriteErrandState extends State<WriteErrand> {
           });
       if (response.statusCode == 200) {
         int errandNo = jsonDecode(response.body)['errandNo'];
+        _insertOverlay(context);
         Navigator.of(context).push(
             MaterialPageRoute(
                 builder: (context) => MainErrandCheck(errandNo: errandNo,)
@@ -185,6 +292,12 @@ class _WriteErrandState extends State<WriteErrand> {
   void initState() {
     // 위젯의 초기 상태 설정 = 상태 변화 감지
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (overlayEntry != null) {
+        overlayEntry!.remove();
+        overlayEntry = null;
+      }
+    });
     titleController.addListener(updateTitleState);
     detailAddressController.addListener(updateDestinationState);
     priceController.addListener(updatePriceState);
@@ -274,112 +387,549 @@ class _WriteErrandState extends State<WriteErrand> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Container(
-        child: SingleChildScrollView(
-          child: Column(
-            children: [
-              Padding(
-                padding: EdgeInsets.only(left: 19.0, top: 34.0),
-                child: Row(
-                  children: [
-                    IconButton(
-                      icon: Icon(Icons.arrow_back_ios),
-                      onPressed: () {
-                        Navigator.of(context).pop();
-                      },
-                    ),
-                    Text(
-                      '요청서 작성하기',
-                      style: TextStyle(
-                        fontFamily: 'Paybooc',
-                        fontWeight: FontWeight.w700,
-                        color: Color(0xff111111),
-                        fontSize: 20,
+    return PopScope(
+        canPop: true,
+        onPopInvoked: (bool didPop) async {
+      if (didPop) {
+        _insertOverlay(context);
+        return;
+      }
+      Navigator.of(context).pop();
+    },
+      child: Scaffold(
+        body: Container(
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                Padding(
+                  padding: EdgeInsets.only(left: 19.0, top: 34.0),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        icon: Icon(Icons.arrow_back_ios),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
                       ),
-                    ),
-                  ],
+                      Text(
+                        '요청서 작성하기',
+                        style: TextStyle(
+                          fontFamily: 'Paybooc',
+                          fontWeight: FontWeight.w700,
+                          color: Color(0xff111111),
+                          fontSize: 20,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-              Container(
-                margin: EdgeInsets.only(top: 34),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Container(
-                        margin: EdgeInsets.only(left: 24),
+                Container(
+                  margin: EdgeInsets.only(top: 34),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Container(
+                          margin: EdgeInsets.only(left: 24),
+                          child: Text(
+                            '제목',
+                            style: TextStyle(
+                              fontFamily: 'Pretendard',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 14,
+                              letterSpacing: 0.01,
+                              color: Color(0xff111111),
+                            ),
+                          ),
+                        ), // 이메일 텍스트 입력 구현(누르면 글자 사라짐)
+                      ),
+                      Container(
+                        margin: EdgeInsets.only(right: 300),
                         child: Text(
-                          '제목',
+                          '*',
                           style: TextStyle(
                             fontFamily: 'Pretendard',
-                            fontWeight: FontWeight.w600,
+                            fontWeight: FontWeight.w500,
                             fontSize: 14,
+                            letterSpacing: 0.01,
+                            color: Color(0xffF05252),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                //제목 텍스트 필드
+                Container(
+                  margin: EdgeInsets.only(left: 20.0, right: 20.0, top: 6.0),
+                  width: 318,
+                  height: 31,
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                        color: Color(0xff2D2D2D), // 테두리 색상
+                        width: 0.5 // 테두리 굵기
+                    ),
+                    borderRadius: BorderRadius.all(Radius.circular(6.0)),
+                    color: Color(0xffFFFFFF), // 텍스트 필드 배경색
+                  ),
+                  child: Padding(
+                    padding: EdgeInsets.only(top: 7.5, left: 10, right: 10),
+                    child: TextField(
+                      maxLength: maxTitleLength,
+                      controller: titleController,
+                      style: TextStyle(
+                        fontFamily: 'Pretendard',
+                        fontWeight: FontWeight.w400,
+                        fontSize: 13,
+                        letterSpacing: 0.01,
+                        color: Color(0xff252525),
+                      ),
+                      decoration: InputDecoration(
+                        border: InputBorder.none,
+                        counterText: '',
+                      ),
+                      keyboardType: TextInputType.text,
+                    ),
+                  ),
+                ),
+
+                // 일정 텍스트
+                Container(
+                  margin: EdgeInsets.only(top: 14),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Container(
+                          margin: EdgeInsets.only(left: 24),
+                          child: Text(
+                            '일정',
+                            style: TextStyle(
+                              fontFamily: 'Pretendard',
+                              fontWeight: FontWeight.w500,
+                              fontSize: 14,
+                              letterSpacing: 0.01,
+                              color: Color(0xff111111),
+                            ),
+                          ),
+                        ), // 이메일 텍스트 입력 구현(누르면 글자 사라짐)
+                      ),
+                      Container(
+                        margin: EdgeInsets.only(right: 2),
+                        child: Text(
+                          '*',
+                          style: TextStyle(
+                            fontFamily: 'Pretendard',
+                            fontWeight: FontWeight.w500,
+                            fontSize: 14,
+                            letterSpacing: 0.01,
+                            color: Color(0xffF05252),
+                          ),
+                        ),
+                      ),
+                      Container(
+                        margin: EdgeInsets.only(right: 121),
+                        child: Text(
+                          '예약은 최대 ?시간 이후까지 가능해요.',
+                          style: TextStyle(
+                            fontFamily: 'Pretendard',
+                            fontWeight: FontWeight.w500,
+                            fontSize: 12,
                             letterSpacing: 0.01,
                             color: Color(0xff111111),
                           ),
                         ),
-                      ), // 이메일 텍스트 입력 구현(누르면 글자 사라짐)
-                    ),
-                    Container(
-                      margin: EdgeInsets.only(right: 300),
-                      child: Text(
-                        '*',
-                        style: TextStyle(
-                          fontFamily: 'Pretendard',
-                          fontWeight: FontWeight.w500,
-                          fontSize: 14,
-                          letterSpacing: 0.01,
-                          color: Color(0xffF05252),
-                        ),
                       ),
-                    ),
-                  ],
-                ),
-              ),
-              //제목 텍스트 필드
-              Container(
-                margin: EdgeInsets.only(left: 20.0, right: 20.0, top: 6.0),
-                width: 318,
-                height: 31,
-                decoration: BoxDecoration(
-                  border: Border.all(
-                      color: Color(0xff2D2D2D), // 테두리 색상
-                      width: 0.5 // 테두리 굵기
-                      ),
-                  borderRadius: BorderRadius.all(Radius.circular(6.0)),
-                  color: Color(0xffFFFFFF), // 텍스트 필드 배경색
-                ),
-                child: Padding(
-                  padding: EdgeInsets.only(top: 7.5, left: 10, right: 10),
-                  child: TextField(
-                    maxLength: maxTitleLength,
-                    controller: titleController,
-                    style: TextStyle(
-                      fontFamily: 'Pretendard',
-                      fontWeight: FontWeight.w400,
-                      fontSize: 13,
-                      letterSpacing: 0.01,
-                      color: Color(0xff252525),
-                    ),
-                    decoration: InputDecoration(
-                      border: InputBorder.none,
-                      counterText: '',
-                    ),
-                    keyboardType: TextInputType.text,
+                    ],
                   ),
                 ),
-              ),
+                Container(
+                  margin: EdgeInsets.only(top: 6, left: 22),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Container(
+                          width: 106,
+                          height: 38,
+                          // 토글 버튼 만들기
+                          margin: EdgeInsets.only(left: 0),
+                          child: ToggleButtons(
+                            color: Color(0xff2E2E2E),
+                            // 선택되지 않은 버튼 텍스트 색상
+                            // 선택되지 않은 버튼 배경색
+                            borderColor: Colors.grey,
+                            // 토글 버튼 테두리 색상
+                            borderWidth: 0.5,
+                            borderRadius: BorderRadius.circular(5.0),
 
-              // 일정 텍스트
-              Container(
-                margin: EdgeInsets.only(top: 14),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Container(
-                        margin: EdgeInsets.only(left: 24),
+                            selectedColor: Color(0xffC77749),
+                            // 선택된 버튼 텍스트 색상
+                            fillColor: Color(0xffFFFFFF),
+                            // 선택된 버튼 배경색
+                            selectedBorderColor: Color(0xffC77749),
+                            // 선택된 버튼 테두리 색상
+
+                            children: <Widget>[
+                              Padding(
+                                padding: EdgeInsets.symmetric(horizontal: 15),
+                                child: Text(
+                                  '오늘',
+                                  style: TextStyle(
+                                    fontFamily: 'Pretendard',
+                                    fontWeight: FontWeight.w400,
+                                    fontSize: 13,
+                                    letterSpacing: 0.01,
+                                  ),
+                                ),
+                              ),
+                              Padding(
+                                padding: EdgeInsets.symmetric(horizontal: 15),
+                                child: Text(
+                                  '내일',
+                                  style: TextStyle(
+                                    fontFamily: 'Pretendard',
+                                    fontWeight: FontWeight.w400,
+                                    fontSize: 13,
+                                    letterSpacing: 0.01,
+                                  ),
+                                ),
+                              ),
+                            ],
+                            isSelected: isSelected1,
+                            onPressed: toggleSelect1,
+                          ),
+                        ),
+                      ),
+                      if (isDetailVisible)
+                      // 시간 상세 설정 카테고리
+                        Container(
+                          margin: EdgeInsets.only(right: 51),
+                          width: 165.28,
+                          height: 38,
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                              color: Color(0xffA9A9A9), // 박스 테두리 색상
+                              width: 0.5, // 테두리 굵기
+                            ),
+                            borderRadius: BorderRadius.all(Radius.circular(5.0)),
+                            color: Color(0xffFFFFFF), // 박스 배경 색상
+                          ),
+                          child: Row(
+                            children: [
+                              Container(
+                                margin: EdgeInsets.only(left: 10),
+                                child: DropdownButton<int>(
+                                  underline: Container(),
+                                  // dropdownButton 밑줄 제거
+                                  value: _selectedHour,
+                                  onChanged: (int? newValue) {
+                                    setState(() {
+                                      _selectedHour = newValue!;
+                                      log(_selectedHour.toString());
+                                    });
+                                  },
+                                  icon: Icon(Icons.keyboard_arrow_down,
+                                      size: 17, color: Color(0xff808080)),
+                                  items: List.generate(24, (index) {
+                                    // 0~23시
+                                    return DropdownMenuItem<int>(
+                                      value: index,
+                                      child: Text(
+                                        '$index',
+                                        style: TextStyle(
+                                          fontFamily: 'Pretendard',
+                                          fontWeight: FontWeight.w400,
+                                          fontSize: 12,
+                                          letterSpacing: 0.01,
+                                          color: Color(0xffC77749),
+                                        ),
+                                      ),
+                                    );
+                                  }),
+                                ),
+                              ),
+                              Container(
+                                margin: EdgeInsets.only(right: 5),
+                                child: Text(
+                                  '시',
+                                  style: TextStyle(
+                                    fontFamily: 'Pretendard',
+                                    fontWeight: FontWeight.w400,
+                                    fontSize: 12,
+                                    letterSpacing: 0.01,
+                                    color: Color(0xff4F4F4F),
+                                  ),
+                                ),
+                              ),
+                              Container(
+                                margin: EdgeInsets.only(left: 10),
+                                child: DropdownButton<int>(
+                                  underline: Container(),
+                                  // dropdownButton 밑줄 제거
+                                  value: _selectedMinute,
+                                  onChanged: (int? newValue) {
+                                    setState(() {
+                                      _selectedMinute = newValue!;
+                                      log(_selectedMinute.toString());
+                                    });
+                                  },
+                                  icon: Icon(Icons.keyboard_arrow_down,
+                                      size: 17, color: Color(0xff808080)),
+                                  items: List.generate(60, (index) {
+                                    // 0~59분
+                                    return DropdownMenuItem<int>(
+                                      value: index,
+                                      child: Text(
+                                        '$index',
+                                        style: TextStyle(
+                                          fontFamily: 'Pretendard',
+                                          fontWeight: FontWeight.w400,
+                                          fontSize: 12,
+                                          letterSpacing: 0.01,
+                                          color: Color(0xffC77749),
+                                        ),
+                                      ),
+                                    );
+                                  }),
+                                ),
+                              ),
+                              Container(
+                                margin: EdgeInsets.only(right: 2),
+                                child: Text(
+                                  '분',
+                                  style: TextStyle(
+                                    fontFamily: 'Pretendard',
+                                    fontWeight: FontWeight.w400,
+                                    fontSize: 12,
+                                    letterSpacing: 0.01,
+                                    color: Color(0xff4F4F4F),
+                                  ),
+                                ),
+                              ),
+                              Container(
+                                margin: EdgeInsets.only(left: 8),
+                                child: Text(
+                                  '까지',
+                                  style: TextStyle(
+                                    fontFamily: 'Pretendard',
+                                    fontWeight: FontWeight.w400,
+                                    fontSize: 12,
+                                    letterSpacing: 0.01,
+                                    color: Color(0xffC77749),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        )
+                    ],
+                  ),
+                ),
+                // 도착지 텍스트
+                Container(
+                  margin: EdgeInsets.only(top: 14),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Container(
+                          margin: EdgeInsets.only(left: 24),
+                          child: Text(
+                            '도착지',
+                            style: TextStyle(
+                              fontFamily: 'Pretendard',
+                              fontWeight: FontWeight.w500,
+                              fontSize: 14,
+                              letterSpacing: 0.01,
+                              color: Color(0xff111111),
+                            ),
+                          ),
+                        ), // 이메일 텍스트 입력 구현(누르면 글자 사라짐)
+                      ),
+                      Container(
+                        margin: EdgeInsets.only(right: 289),
                         child: Text(
-                          '일정',
+                          '*',
+                          style: TextStyle(
+                            fontFamily: 'Pretendard',
+                            fontWeight: FontWeight.w500,
+                            fontSize: 14,
+                            letterSpacing: 0.01,
+                            color: Color(0xffF05252),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                // 네이버 미니 지도
+                Container(
+                  width: 318.85,
+                  height: 120,
+                  margin: EdgeInsets.only(left: 2, top: 6),
+                  decoration: BoxDecoration(
+                    border:
+                    Border.all(color: Color(0xff2D2D2D), width: 0.5 // 테두리 굵기
+                    ),
+                    borderRadius: BorderRadius.all(Radius.circular(5)),
+                    color: Color(0xffFFFFFF),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(5),
+                    child: NaverMap(
+                      options: NaverMapViewOptions(
+                        scrollGesturesEnable: false, // 스크롤 비활성화
+                        zoomGesturesEnable: false, // 줌 비활성화
+
+                        // locationButtonEnable: true, // 내 위치 버튼 활성화
+                        logoClickEnable: false, // 네이버 로고 클릭 비활성화
+
+                        mapType: NMapType.basic, // 지도 유형 : 기본 지도(기본 값)
+                        activeLayerGroups: [ // 표시할 정보
+                          NLayerGroup.building, // 건물 레이어
+                          NLayerGroup.transit, // 대중교통 레이어
+                        ],
+                        initialCameraPosition: NCameraPosition(
+                            target: myLatLng,// 내 위치
+                            // 위도, 경도
+                            // 부경대 대연캠퍼스
+                            // 위도 latitude : 35.134384930841364
+                            // 경도 longitude : 129.10592409493796
+                            zoom: zoom, // 지도의 초기 줌 레벨
+                            bearing: 0, // 지도의 회전 각도(0 : 북쪽이 위)
+                            tilt: 0 // 지도의 기울기 각도(0 : 평면으로 보임)
+                        ),
+                      ),
+
+                      onMapReady: (controller) {
+                        log("request.dart로 이동!");
+                        log(value.toString());
+                        controller.addOverlay(marker); // 마커를 지도 위에 올리기
+                        mapController = controller;
+                        print("네이버 맵 로딩됨!");
+                      },
+
+                      onMapTapped: (point, latLng) async {
+                        // 지도가 터치될 때마다 마커의 위치를 업데이트
+                        print("marker 이동!");
+                        final returnValue = await Navigator.push(
+                          //로그인 버튼 누르면 게시글 페이지로 이동하게 설정
+                          context,
+                          MaterialPageRoute(builder: (context) => NaverMapTest(value: value, zoom: zoom)),
+                        );
+                        // log(point.toString());
+                        // log(latLng.toString());
+
+                        setState(() {
+                          value = returnValue.value;
+                          zoom = returnValue.zoom;
+                          marker.setPosition(value);
+                          marker.setIsVisible(true); // 새로운 값이 들어오면 마커 다시 보이도록 설정
+                        });
+                        mapController.updateCamera(
+                          NCameraUpdate.scrollAndZoomTo(
+                            target : NLatLng(value.latitude, value.longitude),
+                            zoom: zoom,
+                          ),
+                        );
+                      },
+
+                      onSymbolTapped: (symbol) {
+                        setState(() {
+                          marker.setPosition(value);  // marker 위치 이동
+                          marker.setIsVisible(true);
+                        });
+                        final cameraPosition = NCameraPosition(
+                            target: NLatLng(value.latitude, value.longitude),
+                            zoom: zoom
+                        );
+                        final cameraUpdate = NCameraUpdate.fromCameraPosition(cameraPosition);
+                        cameraUpdate.setAnimation(
+                            animation: NCameraAnimation.fly,
+                            duration: Duration(seconds: 2)
+                        );
+                        mapController.updateCamera(cameraUpdate);
+                        log("지도의 심볼 클릭 -> 미니 지도에 표시");
+                      },
+                      forceGesture: true,
+                      // SingleChildScrollView 안에서 사용하므로, NaverMap에
+                      // 전달되는 제스처 무시 현상 방지 위함
+                    ),
+                  ),
+                ),
+                // 상세 주소 텍스트 필드
+                Container(
+                  margin: EdgeInsets.only(left: 20.0, right: 20.0, top: 7.0),
+                  width: 320,
+                  height: 38,
+                  decoration: BoxDecoration(
+                    border:
+                    Border.all(color: Color(0xff2D2D2D), width: 0.5 // 테두리 굵기
+                    ),
+                    borderRadius: BorderRadius.all(Radius.circular(5.0)),
+                    color: Color(0xffFFFFFF),
+                  ),
+                  child: Padding(
+                    padding: EdgeInsets.only(top: 4.75, left: 12.6, right: 8),
+                    child: TextField(
+                      controller: detailAddressController,
+                      style: TextStyle(
+                        fontFamily: 'Pretendard',
+                        fontWeight: FontWeight.w400,
+                        fontSize: 13,
+                        letterSpacing: 0.01,
+                        color: Color(0xff373737),
+                      ),
+                      decoration: InputDecoration(
+                        hintText: '상세 주소를 입력해주세요. ex) 중앙도서관 1층 데스크',
+                        hintStyle: TextStyle(
+                          fontFamily: 'Pretendard',
+                          fontWeight: FontWeight.w400,
+                          fontSize: 12,
+                          letterSpacing: 0.01,
+                          color: Color(0xff878787),
+                        ),
+                        border: InputBorder.none,
+                      ),
+                      keyboardType: TextInputType.text,
+                    ),
+                  ),
+                ),
+
+                // 심부름 값 텍스트, 결제 방법 텍스트
+                Container(
+                  margin: EdgeInsets.only(top: 18),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Container(
+                          margin: EdgeInsets.only(left: 24),
+                          child: Text(
+                            '심부름 값',
+                            style: TextStyle(
+                              fontFamily: 'Pretendard',
+                              fontWeight: FontWeight.w500,
+                              fontSize: 14,
+                              letterSpacing: 0.01,
+                              color: Color(0xff111111),
+                            ),
+                          ),
+                        ), // 이메일 텍스트 입력 구현(누르면 글자 사라짐)
+                      ),
+                      Container(
+                        margin: EdgeInsets.only(right: 70),
+                        child: Text(
+                          '*',
+                          style: TextStyle(
+                            fontFamily: 'Pretendard',
+                            fontWeight: FontWeight.w500,
+                            fontSize: 14,
+                            letterSpacing: 0.01,
+                            color: Color(0xffF05252),
+                          ),
+                        ),
+                      ),
+                      Container(
+                        margin: EdgeInsets.only(right: 2),
+                        child: Text(
+                          '결제 방법',
                           style: TextStyle(
                             fontFamily: 'Pretendard',
                             fontWeight: FontWeight.w500,
@@ -388,51 +938,93 @@ class _WriteErrandState extends State<WriteErrand> {
                             color: Color(0xff111111),
                           ),
                         ),
-                      ), // 이메일 텍스트 입력 구현(누르면 글자 사라짐)
-                    ),
-                    Container(
-                      margin: EdgeInsets.only(right: 2),
-                      child: Text(
-                        '*',
-                        style: TextStyle(
-                          fontFamily: 'Pretendard',
-                          fontWeight: FontWeight.w500,
-                          fontSize: 14,
-                          letterSpacing: 0.01,
-                          color: Color(0xffF05252),
+                      ),
+                      Container(
+                        margin: EdgeInsets.only(right: 142),
+                        child: Text(
+                          '*',
+                          style: TextStyle(
+                            fontFamily: 'Pretendard',
+                            fontWeight: FontWeight.w500,
+                            fontSize: 14,
+                            letterSpacing: 0.01,
+                            color: Color(0xffF05252),
+                          ),
                         ),
                       ),
-                    ),
-                    Container(
-                      margin: EdgeInsets.only(right: 121),
-                      child: Text(
-                        '예약은 최대 ?시간 이후까지 가능해요.',
-                        style: TextStyle(
-                          fontFamily: 'Pretendard',
-                          fontWeight: FontWeight.w500,
-                          fontSize: 12,
-                          letterSpacing: 0.01,
-                          color: Color(0xff111111),
-                        ),
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              Container(
-                margin: EdgeInsets.only(top: 6, left: 22),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Container(
-                        width: 106,
+                // 심부름 값 텍스트 필드, 결제 방법 토글 버튼
+                Container(
+                  margin: EdgeInsets.only(top: 6, left: 20.0),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        // 심부름 값 텍스트 필드
+                        child: Container(
+                          child: Stack(
+                            clipBehavior: Clip.none,
+                            children: <Widget>[
+                              Container(
+                                width: 107,
+                                height: 38,
+                                decoration: BoxDecoration(
+                                  border: Border.all(
+                                      color: Color(0xff2D2D2D),
+                                      width: 0.5 // 테두리 굵기
+                                  ),
+                                  borderRadius:
+                                  BorderRadius.all(Radius.circular(5.0)),
+                                  color: Color(0xffFFFFFF),
+                                ),
+                                child: Padding(
+                                  padding: EdgeInsets.only(
+                                      bottom: 4, left: 27, right: 7.5),
+                                  child: TextField(
+                                    controller: priceController,
+                                    style: TextStyle(
+                                      fontFamily: 'Pretendard',
+                                      fontWeight: FontWeight.w400,
+                                      fontSize: 13,
+                                      letterSpacing: 0.01,
+                                      color: Color(0xff373737),
+                                    ),
+                                    decoration: InputDecoration(
+                                      border: InputBorder.none,
+                                    ),
+                                    keyboardType: TextInputType.number,
+                                  ),
+                                ),
+                              ),
+                              Positioned.fill(
+                                child: Align(
+                                  alignment: Alignment.centerLeft,
+                                  child: Container(
+                                    padding: EdgeInsets.only(left: 12.36, top: 1),
+                                    color: Colors.transparent,
+                                    child: Image.asset(
+                                      'assets/images/₩.png',
+                                      color: Color(0xff7C7C7C),
+                                      width: 11,
+                                      height: 14,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      Container(
+                        width: 119,
                         height: 38,
                         // 토글 버튼 만들기
-                        margin: EdgeInsets.only(left: 0),
+                        margin: EdgeInsets.only(right: 86),
                         child: ToggleButtons(
                           color: Color(0xff2E2E2E),
                           // 선택되지 않은 버튼 텍스트 색상
-                          // 선택되지 않은 버튼 배경색
+
                           borderColor: Colors.grey,
                           // 토글 버튼 테두리 색상
                           borderWidth: 0.5,
@@ -445,11 +1037,12 @@ class _WriteErrandState extends State<WriteErrand> {
                           selectedBorderColor: Color(0xffC77749),
                           // 선택된 버튼 테두리 색상
 
+                          // renderBorder: false,
                           children: <Widget>[
                             Padding(
-                              padding: EdgeInsets.symmetric(horizontal: 15),
+                              padding: EdgeInsets.symmetric(horizontal: 11),
                               child: Text(
-                                '오늘',
+                                '계좌이체',
                                 style: TextStyle(
                                   fontFamily: 'Pretendard',
                                   fontWeight: FontWeight.w400,
@@ -459,9 +1052,9 @@ class _WriteErrandState extends State<WriteErrand> {
                               ),
                             ),
                             Padding(
-                              padding: EdgeInsets.symmetric(horizontal: 15),
+                              padding: EdgeInsets.symmetric(horizontal: 14),
                               child: Text(
-                                '내일',
+                                '현금',
                                 style: TextStyle(
                                   fontFamily: 'Pretendard',
                                   fontWeight: FontWeight.w400,
@@ -471,613 +1064,144 @@ class _WriteErrandState extends State<WriteErrand> {
                               ),
                             ),
                           ],
-                          isSelected: isSelected1,
-                          onPressed: toggleSelect1,
+                          isSelected: isSelected2,
+                          onPressed: toggleSelect2,
                         ),
                       ),
-                    ),
-                    if (isDetailVisible)
-                      // 시간 상세 설정 카테고리
+                    ],
+                  ),
+                ),
+
+                // 요청사항 텍스트
+                Container(
+                  margin: EdgeInsets.only(top: 14),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Container(
+                          margin: EdgeInsets.only(left: 24),
+                          child: Text(
+                            '요청사항',
+                            style: TextStyle(
+                              fontFamily: 'Pretendard',
+                              fontWeight: FontWeight.w500,
+                              fontSize: 14,
+                              letterSpacing: 0.01,
+                              color: Color(0xff111111),
+                            ),
+                          ),
+                        ), // 이메일 텍스트 입력 구현(누르면 글자 사라짐)
+                      ),
                       Container(
-                        margin: EdgeInsets.only(right: 51),
-                        width: 165.28,
-                        height: 38,
-                        decoration: BoxDecoration(
-                          border: Border.all(
-                            color: Color(0xffA9A9A9), // 박스 테두리 색상
-                            width: 0.5, // 테두리 굵기
-                          ),
-                          borderRadius: BorderRadius.all(Radius.circular(5.0)),
-                          color: Color(0xffFFFFFF), // 박스 배경 색상
-                        ),
-                        child: Row(
-                          children: [
-                            Container(
-                              margin: EdgeInsets.only(left: 10),
-                              child: DropdownButton<int>(
-                                underline: Container(),
-                                // dropdownButton 밑줄 제거
-                                value: _selectedHour,
-                                onChanged: (int? newValue) {
-                                  setState(() {
-                                    _selectedHour = newValue!;
-                                    log(_selectedHour.toString());
-                                  });
-                                },
-                                icon: Icon(Icons.keyboard_arrow_down,
-                                    size: 17, color: Color(0xff808080)),
-                                items: List.generate(24, (index) {
-                                  // 0~23시
-                                  return DropdownMenuItem<int>(
-                                    value: index,
-                                    child: Text(
-                                      '$index',
-                                      style: TextStyle(
-                                        fontFamily: 'Pretendard',
-                                        fontWeight: FontWeight.w400,
-                                        fontSize: 12,
-                                        letterSpacing: 0.01,
-                                        color: Color(0xffC77749),
-                                      ),
-                                    ),
-                                  );
-                                }),
-                              ),
-                            ),
-                            Container(
-                              margin: EdgeInsets.only(right: 5),
-                              child: Text(
-                                '시',
-                                style: TextStyle(
-                                  fontFamily: 'Pretendard',
-                                  fontWeight: FontWeight.w400,
-                                  fontSize: 12,
-                                  letterSpacing: 0.01,
-                                  color: Color(0xff4F4F4F),
-                                ),
-                              ),
-                            ),
-                            Container(
-                              margin: EdgeInsets.only(left: 10),
-                              child: DropdownButton<int>(
-                                underline: Container(),
-                                // dropdownButton 밑줄 제거
-                                value: _selectedMinute,
-                                onChanged: (int? newValue) {
-                                  setState(() {
-                                    _selectedMinute = newValue!;
-                                    log(_selectedMinute.toString());
-                                  });
-                                },
-                                icon: Icon(Icons.keyboard_arrow_down,
-                                    size: 17, color: Color(0xff808080)),
-                                items: List.generate(60, (index) {
-                                  // 0~59분
-                                  return DropdownMenuItem<int>(
-                                    value: index,
-                                    child: Text(
-                                      '$index',
-                                      style: TextStyle(
-                                        fontFamily: 'Pretendard',
-                                        fontWeight: FontWeight.w400,
-                                        fontSize: 12,
-                                        letterSpacing: 0.01,
-                                        color: Color(0xffC77749),
-                                      ),
-                                    ),
-                                  );
-                                }),
-                              ),
-                            ),
-                            Container(
-                              margin: EdgeInsets.only(right: 2),
-                              child: Text(
-                                '분',
-                                style: TextStyle(
-                                  fontFamily: 'Pretendard',
-                                  fontWeight: FontWeight.w400,
-                                  fontSize: 12,
-                                  letterSpacing: 0.01,
-                                  color: Color(0xff4F4F4F),
-                                ),
-                              ),
-                            ),
-                            Container(
-                              margin: EdgeInsets.only(left: 8),
-                              child: Text(
-                                '까지',
-                                style: TextStyle(
-                                  fontFamily: 'Pretendard',
-                                  fontWeight: FontWeight.w400,
-                                  fontSize: 12,
-                                  letterSpacing: 0.01,
-                                  color: Color(0xffC77749),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      )
-                  ],
-                ),
-              ),
-              // 도착지 텍스트
-              Container(
-                margin: EdgeInsets.only(top: 14),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Container(
-                        margin: EdgeInsets.only(left: 24),
+                        margin: EdgeInsets.only(right: 275),
                         child: Text(
-                          '도착지',
+                          '*',
                           style: TextStyle(
                             fontFamily: 'Pretendard',
                             fontWeight: FontWeight.w500,
                             fontSize: 14,
                             letterSpacing: 0.01,
-                            color: Color(0xff111111),
+                            color: Color(0xffF05252),
                           ),
                         ),
-                      ), // 이메일 텍스트 입력 구현(누르면 글자 사라짐)
+                      ),
+                    ],
+                  ),
+                ),
+                // 요청사항 텍스트 필드
+                Container(
+                  margin: EdgeInsets.only(left: 20.0, right: 20.0, top: 6.0),
+                  width: 318,
+                  height: 66.56,
+                  decoration: BoxDecoration(
+                    border:
+                    Border.all(color: Color(0xff2D2D2D), width: 0.5 // 테두리 굵기
                     ),
-                    Container(
-                      margin: EdgeInsets.only(right: 289),
-                      child: Text(
-                        '*',
-                        style: TextStyle(
+                    borderRadius: BorderRadius.all(Radius.circular(6.0)),
+                    color: Color(0xffFFFFFF),
+                  ),
+                  child: Padding(
+                    padding: EdgeInsets.only(top: 2, left: 10, right: 10),
+                    // hintText Padding이 이상해서 임의로 설정
+                    child: TextField(
+                      controller: requestController,
+                      style: TextStyle(
+                        fontFamily: 'Pretendard',
+                        fontWeight: FontWeight.w400,
+                        fontSize: 12,
+                        letterSpacing: 0.01,
+                        color: Color(0xff111111),
+                      ),
+                      decoration: InputDecoration(
+                        hintText:
+                        '심부름 내용에 대한 간단한 설명을 적어주세요.\nex) 한 잔만 시럽 2번 추가해 주세요.',
+                        hintStyle: TextStyle(
                           fontFamily: 'Pretendard',
-                          fontWeight: FontWeight.w500,
-                          fontSize: 14,
+                          fontWeight: FontWeight.w400,
+                          fontSize: 12,
                           letterSpacing: 0.01,
-                          color: Color(0xffF05252),
+                          color: Color(0xff878787),
+                        ),
+                        border: InputBorder.none,
+                      ),
+                      maxLines: null,
+                      // 입력 텍스트가 필요한 만큼 자동으로 늘어남
+                      minLines: 1,
+                      // 최소한 1줄 표시
+                      keyboardType: TextInputType.multiline, // 여러 줄 입력 가능하도록 하기
+                    ),
+                  ),
+                ),
+                // 작성 완료 버튼 만들기
+                Container(
+                  margin: EdgeInsets.only(left: 20.0, right: 20.0, top: 20.27),
+                  height: 43,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      errandPostRequest();
+                    },
+                    style: ButtonStyle(
+                      // 버튼의 배경색 변경하기
+                      backgroundColor: MaterialStateProperty.resolveWith<Color>(
+                              (Set<MaterialState> states) {
+                            if (isTitleEnabled &&
+                                isDetailAddressEnabled &&
+                                isPriceEnabled &&
+                                isRequestEnabled) {
+                              return Color(
+                                  0xFF7C3D1A); // 활성화된 배경색(모든 텍스트 필드 비어있지 않은 경우)
+                            } else {
+                              return Color(
+                                  0xFFBD9E8C); // 비활성화 배경색(하나의 텍스트 필드라도 비어있는 경우)
+                            }
+                          }),
+                      // 버튼의 크기 정하기
+                      minimumSize: MaterialStateProperty.all<Size>(Size(318, 41)),
+                      // 버튼의 모양 변경하기
+                      shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                        RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(
+                              5), // 원하는 모양에 따라 BorderRadius 조절
                         ),
                       ),
                     ),
-                  ],
+                    child: Text(
+                      '작성 완료',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontFamily: 'Pretendard',
+                        fontWeight: FontWeight.w600,
+                        color: Color(0xFFFFFFFF),
+                      ),
+                    ),
+                  ),
                 ),
-              ),
-              // 네이버 미니 지도
-          Container(
-                width: 318.85,
-                height: 120,
-                margin: EdgeInsets.only(left: 2, top: 6),
-            decoration: BoxDecoration(
-              border:
-              Border.all(color: Color(0xff2D2D2D), width: 0.5 // 테두리 굵기
-              ),
-              borderRadius: BorderRadius.all(Radius.circular(5)),
-              color: Color(0xffFFFFFF),
+              ],
             ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(5),
-                  child: NaverMap(
-                    options: NaverMapViewOptions(
-                      scrollGesturesEnable: false, // 스크롤 비활성화
-                      zoomGesturesEnable: false, // 줌 비활성화
-
-                      // locationButtonEnable: true, // 내 위치 버튼 활성화
-                      logoClickEnable: false, // 네이버 로고 클릭 비활성화
-
-                      mapType: NMapType.basic, // 지도 유형 : 기본 지도(기본 값)
-                      activeLayerGroups: [ // 표시할 정보
-                        NLayerGroup.building, // 건물 레이어
-                        NLayerGroup.transit, // 대중교통 레이어
-                      ],
-                      initialCameraPosition: NCameraPosition(
-                          target: myLatLng,// 내 위치
-                          // 위도, 경도
-                          // 부경대 대연캠퍼스
-                          // 위도 latitude : 35.134384930841364
-                          // 경도 longitude : 129.10592409493796
-                          zoom: zoom, // 지도의 초기 줌 레벨
-                          bearing: 0, // 지도의 회전 각도(0 : 북쪽이 위)
-                          tilt: 0 // 지도의 기울기 각도(0 : 평면으로 보임)
-                      ),
-                    ),
-
-                    onMapReady: (controller) {
-                      log("request.dart로 이동!");
-                      log(value.toString());
-                      controller.addOverlay(marker); // 마커를 지도 위에 올리기
-                      mapController = controller;
-                      print("네이버 맵 로딩됨!");
-                    },
-
-                    onMapTapped: (point, latLng) async {
-                      // 지도가 터치될 때마다 마커의 위치를 업데이트
-                      print("marker 이동!");
-                      final returnValue = await Navigator.push(
-                            //로그인 버튼 누르면 게시글 페이지로 이동하게 설정
-                              context,
-                              MaterialPageRoute(builder: (context) => NaverMapTest(value: value, zoom: zoom)),
-                          );
-                      // log(point.toString());
-                      // log(latLng.toString());
-
-                      setState(() {
-                        value = returnValue.value;
-                        zoom = returnValue.zoom;
-                        marker.setPosition(value);
-                        marker.setIsVisible(true); // 새로운 값이 들어오면 마커 다시 보이도록 설정
-                      });
-                      mapController.updateCamera(
-                        NCameraUpdate.scrollAndZoomTo(
-                          target : NLatLng(value.latitude, value.longitude),
-                          zoom: zoom,
-                          ),
-                        );
-                    },
-
-                    onSymbolTapped: (symbol) {
-                      setState(() {
-                        marker.setPosition(value);  // marker 위치 이동
-                        marker.setIsVisible(true);
-                      });
-                      final cameraPosition = NCameraPosition(
-                          target: NLatLng(value.latitude, value.longitude),
-                          zoom: zoom
-                      );
-                      final cameraUpdate = NCameraUpdate.fromCameraPosition(cameraPosition);
-                      cameraUpdate.setAnimation(
-                          animation: NCameraAnimation.fly,
-                          duration: Duration(seconds: 2)
-                      );
-                      mapController.updateCamera(cameraUpdate);
-                      log("지도의 심볼 클릭 -> 미니 지도에 표시");
-                    },
-                    forceGesture: true,
-                    // SingleChildScrollView 안에서 사용하므로, NaverMap에
-                    // 전달되는 제스처 무시 현상 방지 위함
-                  ),
-                ),
-              ),
-              // 상세 주소 텍스트 필드
-              Container(
-                margin: EdgeInsets.only(left: 20.0, right: 20.0, top: 7.0),
-                width: 320,
-                height: 38,
-                decoration: BoxDecoration(
-                  border:
-                      Border.all(color: Color(0xff2D2D2D), width: 0.5 // 테두리 굵기
-                          ),
-                  borderRadius: BorderRadius.all(Radius.circular(5.0)),
-                  color: Color(0xffFFFFFF),
-                ),
-                child: Padding(
-                  padding: EdgeInsets.only(top: 4.75, left: 12.6, right: 8),
-                  child: TextField(
-                    controller: detailAddressController,
-                    style: TextStyle(
-                      fontFamily: 'Pretendard',
-                      fontWeight: FontWeight.w400,
-                      fontSize: 13,
-                      letterSpacing: 0.01,
-                      color: Color(0xff373737),
-                    ),
-                    decoration: InputDecoration(
-                      hintText: '상세 주소를 입력해주세요. ex) 중앙도서관 1층 데스크',
-                      hintStyle: TextStyle(
-                        fontFamily: 'Pretendard',
-                        fontWeight: FontWeight.w400,
-                        fontSize: 12,
-                        letterSpacing: 0.01,
-                        color: Color(0xff878787),
-                      ),
-                      border: InputBorder.none,
-                    ),
-                    keyboardType: TextInputType.text,
-                  ),
-                ),
-              ),
-
-              // 심부름 값 텍스트, 결제 방법 텍스트
-              Container(
-                margin: EdgeInsets.only(top: 18),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Container(
-                        margin: EdgeInsets.only(left: 24),
-                        child: Text(
-                          '심부름 값',
-                          style: TextStyle(
-                            fontFamily: 'Pretendard',
-                            fontWeight: FontWeight.w500,
-                            fontSize: 14,
-                            letterSpacing: 0.01,
-                            color: Color(0xff111111),
-                          ),
-                        ),
-                      ), // 이메일 텍스트 입력 구현(누르면 글자 사라짐)
-                    ),
-                    Container(
-                      margin: EdgeInsets.only(right: 70),
-                      child: Text(
-                        '*',
-                        style: TextStyle(
-                          fontFamily: 'Pretendard',
-                          fontWeight: FontWeight.w500,
-                          fontSize: 14,
-                          letterSpacing: 0.01,
-                          color: Color(0xffF05252),
-                        ),
-                      ),
-                    ),
-                    Container(
-                      margin: EdgeInsets.only(right: 2),
-                      child: Text(
-                        '결제 방법',
-                        style: TextStyle(
-                          fontFamily: 'Pretendard',
-                          fontWeight: FontWeight.w500,
-                          fontSize: 14,
-                          letterSpacing: 0.01,
-                          color: Color(0xff111111),
-                        ),
-                      ),
-                    ),
-                    Container(
-                      margin: EdgeInsets.only(right: 142),
-                      child: Text(
-                        '*',
-                        style: TextStyle(
-                          fontFamily: 'Pretendard',
-                          fontWeight: FontWeight.w500,
-                          fontSize: 14,
-                          letterSpacing: 0.01,
-                          color: Color(0xffF05252),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              // 심부름 값 텍스트 필드, 결제 방법 토글 버튼
-              Container(
-                margin: EdgeInsets.only(top: 6, left: 20.0),
-                child: Row(
-                  children: [
-                    Expanded(
-                      // 심부름 값 텍스트 필드
-                      child: Container(
-                        child: Stack(
-                          clipBehavior: Clip.none,
-                          children: <Widget>[
-                            Container(
-                              width: 107,
-                              height: 38,
-                              decoration: BoxDecoration(
-                                border: Border.all(
-                                    color: Color(0xff2D2D2D),
-                                    width: 0.5 // 테두리 굵기
-                                    ),
-                                borderRadius:
-                                    BorderRadius.all(Radius.circular(5.0)),
-                                color: Color(0xffFFFFFF),
-                              ),
-                              child: Padding(
-                                padding: EdgeInsets.only(
-                                    bottom: 4, left: 27, right: 7.5),
-                                child: TextField(
-                                  controller: priceController,
-                                  style: TextStyle(
-                                    fontFamily: 'Pretendard',
-                                    fontWeight: FontWeight.w400,
-                                    fontSize: 13,
-                                    letterSpacing: 0.01,
-                                    color: Color(0xff373737),
-                                  ),
-                                  decoration: InputDecoration(
-                                    border: InputBorder.none,
-                                  ),
-                                  keyboardType: TextInputType.number,
-                                ),
-                              ),
-                            ),
-                            Positioned.fill(
-                              child: Align(
-                                alignment: Alignment.centerLeft,
-                                child: Container(
-                                  padding: EdgeInsets.only(left: 12.36, top: 1),
-                                  color: Colors.transparent,
-                                  child: Image.asset(
-                                    'assets/images/₩.png',
-                                    color: Color(0xff7C7C7C),
-                                    width: 11,
-                                    height: 14,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                    Container(
-                      width: 119,
-                      height: 38,
-                      // 토글 버튼 만들기
-                      margin: EdgeInsets.only(right: 86),
-                      child: ToggleButtons(
-                        color: Color(0xff2E2E2E),
-                        // 선택되지 않은 버튼 텍스트 색상
-
-                        borderColor: Colors.grey,
-                        // 토글 버튼 테두리 색상
-                        borderWidth: 0.5,
-                        borderRadius: BorderRadius.circular(5.0),
-
-                        selectedColor: Color(0xffC77749),
-                        // 선택된 버튼 텍스트 색상
-                        fillColor: Color(0xffFFFFFF),
-                        // 선택된 버튼 배경색
-                        selectedBorderColor: Color(0xffC77749),
-                        // 선택된 버튼 테두리 색상
-
-                        // renderBorder: false,
-                        children: <Widget>[
-                          Padding(
-                            padding: EdgeInsets.symmetric(horizontal: 11),
-                            child: Text(
-                              '계좌이체',
-                              style: TextStyle(
-                                fontFamily: 'Pretendard',
-                                fontWeight: FontWeight.w400,
-                                fontSize: 13,
-                                letterSpacing: 0.01,
-                              ),
-                            ),
-                          ),
-                          Padding(
-                            padding: EdgeInsets.symmetric(horizontal: 14),
-                            child: Text(
-                              '현금',
-                              style: TextStyle(
-                                fontFamily: 'Pretendard',
-                                fontWeight: FontWeight.w400,
-                                fontSize: 13,
-                                letterSpacing: 0.01,
-                              ),
-                            ),
-                          ),
-                        ],
-                        isSelected: isSelected2,
-                        onPressed: toggleSelect2,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-
-              // 요청사항 텍스트
-              Container(
-                margin: EdgeInsets.only(top: 14),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Container(
-                        margin: EdgeInsets.only(left: 24),
-                        child: Text(
-                          '요청사항',
-                          style: TextStyle(
-                            fontFamily: 'Pretendard',
-                            fontWeight: FontWeight.w500,
-                            fontSize: 14,
-                            letterSpacing: 0.01,
-                            color: Color(0xff111111),
-                          ),
-                        ),
-                      ), // 이메일 텍스트 입력 구현(누르면 글자 사라짐)
-                    ),
-                    Container(
-                      margin: EdgeInsets.only(right: 275),
-                      child: Text(
-                        '*',
-                        style: TextStyle(
-                          fontFamily: 'Pretendard',
-                          fontWeight: FontWeight.w500,
-                          fontSize: 14,
-                          letterSpacing: 0.01,
-                          color: Color(0xffF05252),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              // 요청사항 텍스트 필드
-              Container(
-                margin: EdgeInsets.only(left: 20.0, right: 20.0, top: 6.0),
-                width: 318,
-                height: 66.56,
-                decoration: BoxDecoration(
-                  border:
-                      Border.all(color: Color(0xff2D2D2D), width: 0.5 // 테두리 굵기
-                          ),
-                  borderRadius: BorderRadius.all(Radius.circular(6.0)),
-                  color: Color(0xffFFFFFF),
-                ),
-                child: Padding(
-                  padding: EdgeInsets.only(top: 2, left: 10, right: 10),
-                  // hintText Padding이 이상해서 임의로 설정
-                  child: TextField(
-                    controller: requestController,
-                    style: TextStyle(
-                      fontFamily: 'Pretendard',
-                      fontWeight: FontWeight.w400,
-                      fontSize: 12,
-                      letterSpacing: 0.01,
-                      color: Color(0xff111111),
-                    ),
-                    decoration: InputDecoration(
-                      hintText:
-                          '심부름 내용에 대한 간단한 설명을 적어주세요.\nex) 한 잔만 시럽 2번 추가해 주세요.',
-                      hintStyle: TextStyle(
-                        fontFamily: 'Pretendard',
-                        fontWeight: FontWeight.w400,
-                        fontSize: 12,
-                        letterSpacing: 0.01,
-                        color: Color(0xff878787),
-                      ),
-                      border: InputBorder.none,
-                    ),
-                    maxLines: null,
-                    // 입력 텍스트가 필요한 만큼 자동으로 늘어남
-                    minLines: 1,
-                    // 최소한 1줄 표시
-                    keyboardType: TextInputType.multiline, // 여러 줄 입력 가능하도록 하기
-                  ),
-                ),
-              ),
-              // 작성 완료 버튼 만들기
-              Container(
-                margin: EdgeInsets.only(left: 20.0, right: 20.0, top: 20.27),
-                height: 43,
-                child: ElevatedButton(
-                  onPressed: () {
-                    errandPostRequest();
-                  },
-                  style: ButtonStyle(
-                    // 버튼의 배경색 변경하기
-                    backgroundColor: MaterialStateProperty.resolveWith<Color>(
-                        (Set<MaterialState> states) {
-                      if (isTitleEnabled &&
-                          isDetailAddressEnabled &&
-                          isPriceEnabled &&
-                          isRequestEnabled) {
-                        return Color(
-                            0xFF7C3D1A); // 활성화된 배경색(모든 텍스트 필드 비어있지 않은 경우)
-                      } else {
-                        return Color(
-                            0xFFBD9E8C); // 비활성화 배경색(하나의 텍스트 필드라도 비어있는 경우)
-                      }
-                    }),
-                    // 버튼의 크기 정하기
-                    minimumSize: MaterialStateProperty.all<Size>(Size(318, 41)),
-                    // 버튼의 모양 변경하기
-                    shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                      RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(
-                            5), // 원하는 모양에 따라 BorderRadius 조절
-                      ),
-                    ),
-                  ),
-                  child: Text(
-                    '작성 완료',
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontFamily: 'Pretendard',
-                      fontWeight: FontWeight.w600,
-                      color: Color(0xFFFFFFFF),
-                    ),
-                  ),
-                ),
-              ),
-            ],
           ),
         ),
       ),
     );
+
   }
 }

--- a/client/front/pubspec.yaml
+++ b/client/front/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   flutter_native_splash: ^2.4.0
   stomp_dart_client: ^2.0.0
   animated_text_kit: ^4.2.2
+  dropdown_button2: ^2.3.9
 
 
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> ex) #203 

### 📝 주요 작업 내용

> 현황페이지에 오버레이가 정상 표시되도록 했고, 
![image](https://github.com/pknu-wap/2024-1_App1/assets/161244328/8ee6b2b9-4ad5-4371-aa57-10e0586f687e)
마지막 심부름까지 가리는 것 없이 다 표시되도록 리스트 뷰 수정했습니다.
![image](https://github.com/pknu-wap/2024-1_App1/assets/161244328/8819d992-efa6-4f4e-9af4-62da6a4a636f)
![image](https://github.com/pknu-wap/2024-1_App1/assets/161244328/4e65e45f-cb4d-4ee5-8e93-858d251b1ea5)

뒤로가기, 작성완료 시에 오버레이를 다시 넣어주는 함수를 실행시키는 방식으로 해결했습니다.
수정하기 페이지도 마찬가지로 해결했는데 문제 있으면 말해주세요

### 🖼️ 스크린샷 (선택)
![쿼카8](https://github.com/pknu-wap/2024-1_App1/assets/144558971/eb4f46a5-f2ba-4ec2-a6ab-238741b1659e)


### 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?