### PR TITLE
feature/236 사용자 심부름 히스토리 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | **이제희** | **민경윤** | **김수현** | **이강민** | **정다은** |
 | :------: |  :------: | :------: | :------: | :------: |
 | [<img src="https://avatars.githubusercontent.com/JehuiLee" height=150 width=150> <br/> @JehuiLee](https://github.com/JehuiLee) | [<img src="https://avatars.githubusercontent.com/unh6unh6" height=150 width=150> <br/> @unh6unh6](https://github.com/unh6unh6) | [<img src="https://avatars.githubusercontent.com/suhyun113" height=150 width=150> <br/> @suhyun113](https://github.com/suhyun113) | [<img src="https://avatars.githubusercontent.com/mututu17" height=150 width=150> <br/> @mututu17](https://github.com/mututu17) | [![쿼카캐](https://github.com/pknu-wap/2024-1_App1/assets/142780364/722c5729-8f0f-443f-9049-2b8e7694bab9) <br/> 정다은]() |
-| **백엔드** |  **백엔드** | **프론트엔드** | **프론트엔드** | **디자이너** |
+| **백엔드** |  **백엔드** | **클라이언트** | **클라이언트** | **디자이너** |
 
 </div>
 

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -1,6 +1,7 @@
 package com.pknuErrand.appteam.controller.errand;
 
 
+import com.pknuErrand.appteam.domain.member.Member;
 import com.pknuErrand.appteam.dto.errand.*;
 import com.pknuErrand.appteam.exception.ExceptionResponseDto;
 import com.pknuErrand.appteam.service.errand.ErrandService;
@@ -159,5 +160,13 @@ public class ErrandController {
     public ResponseEntity<Map<String, ?>> getErranderInfo(@PathVariable Long errandNo) {
         return ResponseEntity.ok()
                 .body(errandService.getErranderInfo(errandNo));
+    }
+
+    /** **/
+    @GetMapping("/myPostedErrand")
+    public ResponseEntity<List<ErrandListResponseDto>> getMemberPostedErrands() {
+        Member member = memberService.getLoginMember();
+        return ResponseEntity.ok()
+                .body(errandService.getErrandListByOrderNo(member));
     }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/controller/errand/ErrandController.java
@@ -163,10 +163,17 @@ public class ErrandController {
     }
 
     /** **/
-    @GetMapping("/myPostedErrand")
-    public ResponseEntity<List<ErrandListResponseDto>> getMemberPostedErrands() {
+    @GetMapping("/myErrand/order")
+    public ResponseEntity<List<ErrandListResponseDto>> getMemberOrderErrands() {
         Member member = memberService.getLoginMember();
         return ResponseEntity.ok()
                 .body(errandService.getErrandListByOrderNo(member));
+    }
+
+    @GetMapping("/myErrand/errander")
+    public ResponseEntity<List<ErrandListResponseDto>> getMemberErranderErrands() {
+        Member member = memberService.getLoginMember();
+        return ResponseEntity.ok()
+                .body(errandService.getErrandListByErranderNo(member));
     }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandRepository.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandRepository.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.parameters.P;
 import java.util.List;
 
 public interface ErrandRepository extends JpaRepository<Errand, Long> {
+    List<Errand> findErrandByOrderNo(Member orderNo);
 
     @Query(value = "SELECT * " +
             "FROM errand " +

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandRepository.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/repository/errand/ErrandRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 public interface ErrandRepository extends JpaRepository<Errand, Long> {
     List<Errand> findErrandByOrderNo(Member orderNo);
+    List<Errand> findErrandByErranderNo(Member erranderNo);
 
     @Query(value = "SELECT * " +
             "FROM errand " +

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -265,4 +265,11 @@ public class ErrandService {
         infoMap.put("nickname", errand.getErranderNo().getNickname());
         return infoMap;
     }
+    /** **/
+    @Transactional
+    public List<ErrandListResponseDto> getErrandListByOrderNo(Member member) {
+        List<ErrandListResponseDto> errandList = null;
+        errandList = getFilteredErrandList(errandRepository.findErrandByOrderNo(member));
+        return errandList;
+    }
 }

--- a/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
+++ b/server/appteam/src/main/java/com/pknuErrand/appteam/service/errand/ErrandService.java
@@ -272,4 +272,11 @@ public class ErrandService {
         errandList = getFilteredErrandList(errandRepository.findErrandByOrderNo(member));
         return errandList;
     }
+
+    @Transactional
+        public List<ErrandListResponseDto> getErrandListByErranderNo(Member member) {
+        List<ErrandListResponseDto> errandList = null;
+        errandList = getFilteredErrandList(errandRepository.findErrandByErranderNo(member));
+        return errandList;
+    }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #236 

### 📝 주요 작업 내용

- 내가올린심부름 api 추가
```java
    @GetMapping("/myErrand/order")
    public ResponseEntity<List<ErrandListResponseDto>> getMemberOrderErrands() {
        Member member = memberService.getLoginMember();
        return ResponseEntity.ok()
                .body(errandService.getErrandListByOrderNo(member));
    }
```
- 내가한심부름 api 추가
```java
    @GetMapping("/myErrand/errander")
    public ResponseEntity<List<ErrandListResponseDto>> getMemberErranderErrands() {
        Member member = memberService.getLoginMember();
        return ResponseEntity.ok()
                .body(errandService.getErrandListByErranderNo(member));
    }
```

- service layer에서 사용자 본인의 심부름 정보를 얻는 것이 아니라, member 객체를 이용해서 각각 조회하기 때문에 차후에 원하는 member의 심부름 정보를 조회할 때 다시 사용가능할듯??