### PR TITLE
feature/245 feat 마이페이지 회원 정보 프로필 이미지

### DIFF
--- a/client/front/lib/screens/main/my_page/user_info/my_page_user_info.dart
+++ b/client/front/lib/screens/main/my_page/user_info/my_page_user_info.dart
@@ -10,17 +10,21 @@ class MyPageUserInfo extends StatefulWidget {
 }
 
 class _MyPageUserInfoState extends State<MyPageUserInfo> {
-  String _profileImagePath = 'assets/images/Avatar.svg'; // Default image path
+  String _profileImagePath = 'assets/images/Avatar.svg'; // 기본 프로필 이미지
+  bool _isSvg = true; // svg 이미지
 
-  void _updateProfileImage(String newImagePath) {
+  void _updateProfileImage(String newImagePath, bool newIsSvg) {
     setState(() {
       _profileImagePath = newImagePath;
+      _isSvg = newIsSvg;
     });
   }
 
+  // 리셋 버튼 클릭 시
   void _resetProfileImage() {
     setState(() {
-      _profileImagePath = 'assets/images/Avatar.svg'; // Reset to default image
+      _profileImagePath = 'assets/images/Avatar.svg'; // 기본 프로필 이미지
+      _isSvg = true;
     });
   }
 
@@ -33,6 +37,7 @@ class _MyPageUserInfoState extends State<MyPageUserInfo> {
           children: [
             UserImage(
               imagePath: _profileImagePath, // Pass current profile image
+              isSvg: _isSvg,
               onTap: () {
                 showModalBottomSheet(
                   context: context,
@@ -44,8 +49,9 @@ class _MyPageUserInfoState extends State<MyPageUserInfo> {
                   builder: (context) => SlideUpBottom(
                     nickName: "수현수현이",
                     initialImagePath: _profileImagePath,
-                    onImageSaved: (newImagePath) {
-                      _updateProfileImage(newImagePath);
+                    initialIsSvg: _isSvg,
+                    onImageSaved: (newImagePath, newIsSvg) {
+                      _updateProfileImage(newImagePath, newIsSvg);
                     },
                     onReset: _resetProfileImage,
                   ),

--- a/client/front/lib/screens/main/my_page/user_info/my_page_user_info.dart
+++ b/client/front/lib/screens/main/my_page/user_info/my_page_user_info.dart
@@ -1,7 +1,6 @@
-// 회원 정보 수정
 import 'package:flutter/material.dart';
-
 import 'user_info_column_list.dart';
+import 'user_info_slide_up_bottom.dart';
 import 'user_info_user_image.dart';
 import 'widgets/my_page_app_bar.dart';
 
@@ -11,6 +10,19 @@ class MyPageUserInfo extends StatefulWidget {
 }
 
 class _MyPageUserInfoState extends State<MyPageUserInfo> {
+  String _profileImagePath = 'assets/images/Avatar.svg'; // Default image path
+
+  void _updateProfileImage(String newImagePath) {
+    setState(() {
+      _profileImagePath = newImagePath;
+    });
+  }
+
+  void _resetProfileImage() {
+    setState(() {
+      _profileImagePath = 'assets/images/Avatar.svg'; // Reset to default image
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +31,28 @@ class _MyPageUserInfoState extends State<MyPageUserInfo> {
       body: Center(
         child: Column(
           children: [
-            UserImage(),
+            UserImage(
+              imagePath: _profileImagePath, // Pass current profile image
+              onTap: () {
+                showModalBottomSheet(
+                  context: context,
+                  isScrollControlled: true,
+                  backgroundColor: Colors.transparent,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+                  ),
+                  builder: (context) => SlideUpBottom(
+                    nickName: "수현수현이",
+                    initialImagePath: _profileImagePath,
+                    onImageSaved: (newImagePath) {
+                      _updateProfileImage(newImagePath);
+                    },
+                    onReset: _resetProfileImage,
+                  ),
+                );
+
+              },
+            ),
             ColumnList(),
           ],
         ),

--- a/client/front/lib/screens/main/my_page/user_info/user_info_slide_up_bottom.dart
+++ b/client/front/lib/screens/main/my_page/user_info/user_info_slide_up_bottom.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:front/screens/main/my_page/widgets/my_page_text.dart';
+import 'widgets/slide_up_bottom_white_container.dart';
+
+class SlideUpBottom extends StatelessWidget {
+  final String nickName;
+  final String initialImagePath;
+  final Function(String) onImageSaved;
+  final VoidCallback onReset;
+
+  SlideUpBottom({
+    required this.nickName,
+    required this.initialImagePath,
+    required this.onImageSaved,
+    required this.onReset,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // 회색 슬라이드
+    return Container(
+      height: 500.h,
+      decoration: BoxDecoration(
+        color: Color(0xffF2F2F2),
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(20.0),
+          topRight: Radius.circular(20.0),
+        ),
+      ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Positioned(
+            top: 13.47.h,
+            // 흰색 컨테이너
+            child: Container(
+              width: 104.51.w,
+              height: 5.h,
+              decoration: BoxDecoration(
+                color: Color(0xffAEAEAE),
+                borderRadius: BorderRadius.all(
+                  Radius.circular(20.0),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            top: 49.38.h,
+            left: 20.w,
+            child: title('$nickName님,'),
+          ),
+          Positioned(
+            top: 66.38.h,
+            left: 20.w,
+            child: title('프로필 이미지를 바꿔보세요'),
+          ),
+          Positioned(
+            top: 112.h,
+            left: 0.w,
+            right: 0.w,
+            child: SlideUpBottomWhiteContainer( // 흰색 컨테이너 내용
+              initialImagePath: initialImagePath,
+              onImageSaved: onImageSaved,
+              onReset: onReset,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/client/front/lib/screens/main/my_page/user_info/user_info_slide_up_bottom.dart
+++ b/client/front/lib/screens/main/my_page/user_info/user_info_slide_up_bottom.dart
@@ -6,12 +6,14 @@ import 'widgets/slide_up_bottom_white_container.dart';
 class SlideUpBottom extends StatelessWidget {
   final String nickName;
   final String initialImagePath;
-  final Function(String) onImageSaved;
+  final bool initialIsSvg;
+  final Function(String, bool) onImageSaved;
   final VoidCallback onReset;
 
   SlideUpBottom({
     required this.nickName,
     required this.initialImagePath,
+    required this.initialIsSvg,
     required this.onImageSaved,
     required this.onReset,
   });
@@ -61,6 +63,7 @@ class SlideUpBottom extends StatelessWidget {
             right: 0.w,
             child: SlideUpBottomWhiteContainer( // 흰색 컨테이너 내용
               initialImagePath: initialImagePath,
+              initialIsSvg: initialIsSvg,
               onImageSaved: onImageSaved,
               onReset: onReset,
             ),

--- a/client/front/lib/screens/main/my_page/user_info/user_info_user_image.dart
+++ b/client/front/lib/screens/main/my_page/user_info/user_info_user_image.dart
@@ -1,14 +1,18 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class UserImage extends StatelessWidget {
   final String imagePath;
+  final bool isSvg;
   final VoidCallback onTap;
 
   const UserImage({
     Key? key,
     required this.imagePath,
+    required this.isSvg,
     required this.onTap,
   }) : super(key: key);
 
@@ -28,10 +32,19 @@ class UserImage extends StatelessWidget {
             // 프로필 이미지
             Align(
               alignment: Alignment.center,
-              child: SvgPicture.asset(
+              child: isSvg ?
+              SvgPicture.asset(
                 imagePath,
                 width: 95.w,
                 height: 90.h,
+              ) : ClipRRect(
+                borderRadius: BorderRadius.circular(200.0),
+                child: Image.file(
+                  File(imagePath),
+                  width: 95.w,
+                  height: 90.h,
+                  fit: BoxFit.cover,
+                ),
               ),
             ),
             // 프로필 이미지 카메라 아이콘

--- a/client/front/lib/screens/main/my_page/user_info/user_info_user_image.dart
+++ b/client/front/lib/screens/main/my_page/user_info/user_info_user_image.dart
@@ -1,15 +1,21 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:flutter_svg/svg.dart';
 
 class UserImage extends StatelessWidget {
+  final String imagePath;
+  final VoidCallback onTap;
+
+  const UserImage({
+    Key? key,
+    required this.imagePath,
+    required this.onTap,
+  }) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
-        print("프로필 이미지 변경 클릭!");
-      },
+      onTap: onTap,
       child: Container(
         margin: EdgeInsets.only(top: 90.h),
         width: 115.w,
@@ -19,22 +25,18 @@ class UserImage extends StatelessWidget {
         ),
         child: Stack(
           children: [
-            // 프로필 이미지
             Align(
               alignment: Alignment.center,
-              child: Container(
-                child: SvgPicture.asset(
-                  'assets/images/Avatar.svg',
-                  width: 95.w,
-                  height: 90.h,
-                ),
+              child: SvgPicture.asset(
+                imagePath,
+                width: 95.w,
+                height: 90.h,
               ),
             ),
-            // 카메라 이미지 버튼
             Align(
               alignment: Alignment.centerRight,
               child: Container(
-                margin: EdgeInsets.only(top: 55.h, right: 10.w), // Adjust margins
+                margin: EdgeInsets.only(top: 55.h, right: 10.w),
                 child: SvgPicture.asset(
                   'assets/images/camera.svg',
                   width: 21.w,

--- a/client/front/lib/screens/main/my_page/user_info/user_info_user_image.dart
+++ b/client/front/lib/screens/main/my_page/user_info/user_info_user_image.dart
@@ -25,6 +25,7 @@ class UserImage extends StatelessWidget {
         ),
         child: Stack(
           children: [
+            // 프로필 이미지
             Align(
               alignment: Alignment.center,
               child: SvgPicture.asset(
@@ -33,6 +34,7 @@ class UserImage extends StatelessWidget {
                 height: 90.h,
               ),
             ),
+            // 프로필 이미지 카메라 아이콘
             Align(
               alignment: Alignment.centerRight,
               child: Container(

--- a/client/front/lib/screens/main/my_page/user_info/widgets/camera/camera.view.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/camera/camera.view.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+class CameraView extends StatefulWidget {
+  final ImageSource imageSource;
+
+  const CameraView({Key? key, required this.imageSource}) : super(key: key);
+
+  @override
+  _CameraViewState createState() => _CameraViewState();
+}
+
+class _CameraViewState extends State<CameraView> {
+  final ImagePicker _picker = ImagePicker();
+  XFile? _imageFile;
+
+  // 이미지 선택하고 상태 업데이트
+  Future<void> _getImage() async {
+    try {
+      final XFile? imageFile = await _picker.pickImage(
+        source: widget.imageSource,
+        maxHeight: 300,
+        maxWidth: 300,
+      );
+
+      if (imageFile != null) {
+        setState(() {
+          _imageFile = imageFile;
+        });
+        Navigator.pop(context, _imageFile?.path);
+      }
+    } catch (e) {
+      print("Error picking image: $e");
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _getImage();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: _imageFile != null
+            ? Image.file(File(_imageFile!.path))
+            : const CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/client/front/lib/screens/main/my_page/user_info/widgets/camera/camera.widget.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/camera/camera.widget.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+class CameraWidget extends StatefulWidget {
+  final ImageSource imageSource;
+
+  const CameraWidget({Key? key, required this.imageSource}) : super(key: key);
+
+  @override
+  State<CameraWidget> createState() => _CameraWidgetState();
+}
+
+// 선택한 이미지 파일 보관
+class _CameraWidgetState extends State<CameraWidget> {
+  final ImagePicker picker = ImagePicker();
+  XFile? _imageFile;
+
+  Future<void> getImage() async {
+    try {
+      final XFile? imageFile = await picker.pickImage(
+        source: widget.imageSource,
+        maxHeight: 300,
+        maxWidth: 300,
+      );
+
+      if (imageFile != null) {
+        setState(() {
+          _imageFile = imageFile;
+        });
+      }
+    } catch (e) {
+      print("Error picking image: $e");
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error picking image: $e')),
+      );
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    getImage(); // 이미지 선택 시작 위해 호출
+  }
+
+  // 이미지 선택
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            _imageFile != null
+                ? Image.file(File(_imageFile!.path))
+                : const Text("Loading..."),
+            SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context, _imageFile?.path);
+              },
+              child: const Text("Done"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client/front/lib/screens/main/my_page/user_info/widgets/slide_up_bottom_white_container.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/slide_up_bottom_white_container.dart
@@ -6,11 +6,13 @@ import 'white_container/white_container_user_image_row_list.dart';
 
 class SlideUpBottomWhiteContainer extends StatefulWidget {
   final String initialImagePath;
-  final Function(String) onImageSaved;
+  final bool initialIsSvg;
+  final Function(String, bool) onImageSaved;
   final VoidCallback onReset;
 
   SlideUpBottomWhiteContainer({
     required this.initialImagePath,
+    required this.initialIsSvg,
     required this.onImageSaved,
     required this.onReset,
   });
@@ -21,11 +23,13 @@ class SlideUpBottomWhiteContainer extends StatefulWidget {
 
 class _SlideUpBottomWhiteContainerState extends State<SlideUpBottomWhiteContainer> {
   late String _selectedImage;
+  late bool _isSvg;
 
   @override
   void initState() {
     super.initState();
     _selectedImage = widget.initialImagePath;
+    _isSvg = widget.initialIsSvg;
   }
 
   @override
@@ -43,14 +47,15 @@ class _SlideUpBottomWhiteContainerState extends State<SlideUpBottomWhiteContaine
       child: Column(
         children: [
           // 흰색 컨테이너 안 프로필 이미지 미리 보기
-          WhiteContainerUserImage(selectedImagePath: _selectedImage),
+          WhiteContainerUserImage(selectedImagePath: _selectedImage, isSvg: _isSvg,),
 
           // 이미지 선택 가로 슬라이드 및 페이지 번호 현황 나타냄
           Expanded(
             child: WhiteContainerUserImageRowList(
-              onImageSelected: (newImagePath) {
+              onImageSelected: (newImagePath, newIsSvg) {
                 setState(() {
                   _selectedImage = newImagePath;
+                  _isSvg = newIsSvg;
                 });
               },
             ),
@@ -61,7 +66,7 @@ class _SlideUpBottomWhiteContainerState extends State<SlideUpBottomWhiteContaine
             padding: EdgeInsets.symmetric(vertical: 20.h),
             child: WhiteContainerRowButtonList(
               onSave: () {
-                widget.onImageSaved(_selectedImage);
+                widget.onImageSaved(_selectedImage, _isSvg);
                 Navigator.pop(context);
               },
               onReset: () {

--- a/client/front/lib/screens/main/my_page/user_info/widgets/slide_up_bottom_white_container.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/slide_up_bottom_white_container.dart
@@ -30,6 +30,7 @@ class _SlideUpBottomWhiteContainerState extends State<SlideUpBottomWhiteContaine
 
   @override
   Widget build(BuildContext context) {
+    // 프로필 이미지 선택 흰색 컨테이너
     return Container(
       height: 390.h,
       decoration: BoxDecoration(
@@ -41,11 +42,11 @@ class _SlideUpBottomWhiteContainerState extends State<SlideUpBottomWhiteContaine
       ),
       child: Column(
         children: [
-          //사용자 이미지 선택 미리 보기
-          WhiteContainerUserImage(selectedImage: _selectedImage),
-          // Image selection grid
+          // 흰색 컨테이너 안 프로필 이미지 미리 보기
+          WhiteContainerUserImage(selectedImagePath: _selectedImage),
+
+          // 이미지 선택 가로 슬라이드 및 페이지 번호 현황 나타냄
           Expanded(
-            // 사용자 이미지 선택 가로 목록
             child: WhiteContainerUserImageRowList(
               onImageSelected: (newImagePath) {
                 setState(() {
@@ -54,12 +55,13 @@ class _SlideUpBottomWhiteContainerState extends State<SlideUpBottomWhiteContaine
               },
             ),
           ),
+
+          // 지우기 및 저장 버튼
           Padding(
             padding: EdgeInsets.symmetric(vertical: 20.h),
-            // 지우기 버튼 및 저장 버튼
             child: WhiteContainerRowButtonList(
               onSave: () {
-                widget.onImageSaved(_selectedImage); // 현재 선택한 이미지 함께 회원 정보 페이지로 넘기기
+                widget.onImageSaved(_selectedImage);
                 Navigator.pop(context);
               },
               onReset: () {
@@ -73,3 +75,4 @@ class _SlideUpBottomWhiteContainerState extends State<SlideUpBottomWhiteContaine
     );
   }
 }
+

--- a/client/front/lib/screens/main/my_page/user_info/widgets/slide_up_bottom_white_container.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/slide_up_bottom_white_container.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'white_container/white_container_row_button_list.dart';
+import 'white_container/white_container_user_image.dart';
+import 'white_container/white_container_user_image_row_list.dart';
+
+class SlideUpBottomWhiteContainer extends StatefulWidget {
+  final String initialImagePath;
+  final Function(String) onImageSaved;
+  final VoidCallback onReset;
+
+  SlideUpBottomWhiteContainer({
+    required this.initialImagePath,
+    required this.onImageSaved,
+    required this.onReset,
+  });
+
+  @override
+  _SlideUpBottomWhiteContainerState createState() => _SlideUpBottomWhiteContainerState();
+}
+
+class _SlideUpBottomWhiteContainerState extends State<SlideUpBottomWhiteContainer> {
+  late String _selectedImage;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedImage = widget.initialImagePath;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 390.h,
+      decoration: BoxDecoration(
+        color: Color(0xffFFFFFF),
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(20.0),
+          topRight: Radius.circular(20.0),
+        ),
+      ),
+      child: Column(
+        children: [
+          //사용자 이미지 선택 미리 보기
+          WhiteContainerUserImage(selectedImage: _selectedImage),
+          // Image selection grid
+          Expanded(
+            // 사용자 이미지 선택 가로 목록
+            child: WhiteContainerUserImageRowList(
+              onImageSelected: (newImagePath) {
+                setState(() {
+                  _selectedImage = newImagePath;
+                });
+              },
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 20.h),
+            // 지우기 버튼 및 저장 버튼
+            child: WhiteContainerRowButtonList(
+              onSave: () {
+                widget.onImageSaved(_selectedImage); // 현재 선택한 이미지 함께 회원 정보 페이지로 넘기기
+                Navigator.pop(context);
+              },
+              onReset: () {
+                widget.onReset();
+                Navigator.pop(context);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_row_button.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_row_button.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:front/widgets/text/button_text.dart';
+
+// 흰색 미니 버튼
+Widget whiteMiniButton({required String text, required VoidCallback onPressed}) {
+  return ElevatedButton(
+    onPressed: onPressed,
+    style: ButtonStyle(
+      backgroundColor: MaterialStateProperty.all<Color>(Color(0xFFFFFFFF)),
+      minimumSize: MaterialStateProperty.all<Size>(Size(134.18.w, 45.h)),
+      shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+        RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(5),
+          side: BorderSide(
+            color: Color(0xff999999),
+            width: 1.0,
+          ),
+        ),
+      ),
+    ),
+    child: whiteButtonText(text),
+  );
+}
+
+// 갈색 미니 버튼
+Widget brownMiniButton({required String text, required VoidCallback onPressed}) {
+  return ElevatedButton(
+    onPressed: onPressed,
+    style: ButtonStyle(
+      backgroundColor: MaterialStateProperty.all<Color>(Color(0xFF7C3D1A)),
+      minimumSize: MaterialStateProperty.all<Size>(Size(134.18.w, 45.h)),
+      shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+        RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(5),
+        ),
+      ),
+    ),
+    child: buttonText(text),
+  );
+}

--- a/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_row_button_list.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_row_button_list.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'white_container_row_button.dart';
+
+class WhiteContainerRowButtonList extends StatelessWidget {
+  final VoidCallback onReset;
+  final VoidCallback onSave;
+
+  WhiteContainerRowButtonList({
+    required this.onReset,
+    required this.onSave,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          // 흰색 미니 버튼
+          whiteMiniButton(
+            text: '지우기',
+            onPressed: onReset,
+          ),
+          // 갈색 미니 버튼
+          brownMiniButton(
+            text: '저장',
+            onPressed: onSave,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image.dart
@@ -23,11 +23,14 @@ class WhiteContainerUserImage extends StatelessWidget {
         width: 86.w,
         height: 83.99.h,
       )
-          : Image.file( // 카메라, 갤러리에서 선택한 이미지
-        File(selectedImagePath),
-        width: 86.w,
-        height: 83.99.h,
-        fit: BoxFit.cover,
+          : ClipRRect(
+        borderRadius: BorderRadius.circular(200.0),
+        child: Image.file( // 카메라, 갤러리에서 선택한 이미지
+          File(selectedImagePath),
+          width: 86.w,
+          height: 83.99.h,
+          fit: BoxFit.cover,
+        ),
       ),
     );
   }

--- a/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image.dart
@@ -1,21 +1,33 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
-
 class WhiteContainerUserImage extends StatelessWidget {
-  final String selectedImage;
+  final String selectedImagePath;
+  final bool isSvg;
 
-  WhiteContainerUserImage({required this.selectedImage});
+  const WhiteContainerUserImage({
+    Key? key,
+    required this.selectedImagePath,
+    this.isSvg = true,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Container(
       margin: EdgeInsets.only(top: 35.39.h),
-      child: SvgPicture.asset(
-        selectedImage,
+      child: isSvg
+          ? SvgPicture.asset( // 커카 이미지
+        selectedImagePath,
         width: 86.w,
         height: 83.99.h,
+      )
+          : Image.file( // 카메라, 갤러리에서 선택한 이미지
+        File(selectedImagePath),
+        width: 86.w,
+        height: 83.99.h,
+        fit: BoxFit.cover,
       ),
     );
   }

--- a/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+
+class WhiteContainerUserImage extends StatelessWidget {
+  final String selectedImage;
+
+  WhiteContainerUserImage({required this.selectedImage});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(top: 35.39.h),
+      child: SvgPicture.asset(
+        selectedImage,
+        width: 86.w,
+        height: 83.99.h,
+      ),
+    );
+  }
+}

--- a/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image_row_list.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image_row_list.dart
@@ -5,7 +5,7 @@ import 'package:front/screens/main/my_page/user_info/widgets/camera/camera.view.
 import 'package:image_picker/image_picker.dart';
 
 class WhiteContainerUserImageRowList extends StatefulWidget {
-  final Function(String) onImageSelected;
+  final Function(String, bool) onImageSelected;
 
   WhiteContainerUserImageRowList({required this.onImageSelected});
 
@@ -74,7 +74,7 @@ class _WhiteContainerUserImageRowListState extends State<WhiteContainerUserImage
         ),
       );
       if (imagePath != null && imagePath.isNotEmpty) {
-        widget.onImageSelected(imagePath);
+        widget.onImageSelected(imagePath, false); // 카메라 이미지 출력
       }
     } else if (imageIndex == 4) { // 갤러리 이미지
       // 갤러리 선택
@@ -85,10 +85,10 @@ class _WhiteContainerUserImageRowListState extends State<WhiteContainerUserImage
         ),
       );
       if (imagePath != null && imagePath.isNotEmpty) {
-        widget.onImageSelected(imagePath);
+        widget.onImageSelected(imagePath, false); // 갤러리 이미지 출력
       }
     } else { // 0, 4 제외한 나머지 이미지
-      widget.onImageSelected(userImagePaths[imageIndex]);
+      widget.onImageSelected(userImagePaths[imageIndex], true); // 캐릭터 이미지 출력
     }
   }
 

--- a/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image_row_list.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image_row_list.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class WhiteContainerUserImageRowList extends StatefulWidget {
+  final Function(String) onImageSelected;
+
+  WhiteContainerUserImageRowList({required this.onImageSelected});
+
+  @override
+  _WhiteContainerUserImageRowListState createState() =>
+      _WhiteContainerUserImageRowListState();
+}
+
+class _WhiteContainerUserImageRowListState
+    extends State<WhiteContainerUserImageRowList> {
+  final List<String> userImagePaths = [
+    'assets/images/userImageCamera.svg',
+    'assets/images/userImage1.svg',
+    'assets/images/userImage2.svg',
+    'assets/images/userImage3.svg',
+    'assets/images/userImageGallery.svg',
+    'assets/images/userImage4.svg',
+    'assets/images/userImage5.svg',
+    'assets/images/userImage6.svg',
+    'assets/images/userImage7.svg',
+    'assets/images/userImage8.svg',
+    'assets/images/userImage9.svg',
+    'assets/images/userImage10.svg',
+    'assets/images/userImage11.svg',
+    'assets/images/userImage12.svg',
+    'assets/images/userImage13.svg',
+    'assets/images/userImage14.svg',
+    'assets/images/userImage1.svg',
+    'assets/images/userImage2.svg',
+    'assets/images/userImage3.svg',
+    'assets/images/userImage4.svg',
+    'assets/images/userImage5.svg',
+    'assets/images/userImage6.svg',
+    'assets/images/userImage7.svg',
+    'assets/images/userImage8.svg',
+  ];
+
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController.addListener(() {
+      int next = _pageController.page!.round();
+      if (_currentPage != next) {
+        setState(() {
+          _currentPage = next;
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    int pageCount = (userImagePaths.length / 8).ceil();
+
+    return Expanded(
+      child: Column(
+        children: [
+          Expanded(
+            child: PageView.builder(
+              controller: _pageController,
+              itemCount: pageCount,
+              itemBuilder: (context, pageIndex) {
+                return GridView.builder(
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 4,
+                    crossAxisSpacing: 28.w,
+                    mainAxisSpacing: 13.h,
+                  ),
+                  physics: NeverScrollableScrollPhysics(),
+                  padding: EdgeInsets.only(
+                    left: 33.w,
+                    right: 33.w,
+                    top: 22.h,
+                    bottom: 94.53.h,
+                  ),
+                  itemCount: 8,
+                  itemBuilder: (context, index) {
+                    final imageIndex = pageIndex * 8 + index;
+                    if (imageIndex < userImagePaths.length) {
+                      return GestureDetector(
+                        onTap: () {
+                          widget.onImageSelected(userImagePaths[imageIndex]);
+                        },
+                        child: Container(
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(200.0),
+                          ),
+                          child: Center(
+                            child: SvgPicture.asset(
+                              userImagePaths[imageIndex],
+                              width: 50.sp,
+                              height: 50.sp,
+                            ),
+                          ),
+                        ),
+                      );
+                    }
+                    return SizedBox();
+                  },
+                );
+              },
+            ),
+          ),
+          // 페이지 수 및 현재 페이지 위치
+          Padding(
+            padding: EdgeInsets.only(bottom: 0.h),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(
+                pageCount,
+                    (index) => Container(
+                  margin: EdgeInsets.symmetric(horizontal: 8.w),
+                  width: 6.w,
+                  height: 6.w,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: _currentPage == index
+                        ? Color(0xff7C3D1A)
+                        : Color(0xffD9D9D9),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image_row_list.dart
+++ b/client/front/lib/screens/main/my_page/user_info/widgets/white_container/white_container_user_image_row_list.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:front/screens/main/my_page/user_info/widgets/camera/camera.view.dart';
+import 'package:image_picker/image_picker.dart';
 
 class WhiteContainerUserImageRowList extends StatefulWidget {
   final Function(String) onImageSelected;
@@ -8,12 +10,11 @@ class WhiteContainerUserImageRowList extends StatefulWidget {
   WhiteContainerUserImageRowList({required this.onImageSelected});
 
   @override
-  _WhiteContainerUserImageRowListState createState() =>
-      _WhiteContainerUserImageRowListState();
+  _WhiteContainerUserImageRowListState createState() => _WhiteContainerUserImageRowListState();
 }
 
-class _WhiteContainerUserImageRowListState
-    extends State<WhiteContainerUserImageRowList> {
+class _WhiteContainerUserImageRowListState extends State<WhiteContainerUserImageRowList> {
+  // 이미지 선택 가로 슬라이드 이미지 목록
   final List<String> userImagePaths = [
     'assets/images/userImageCamera.svg',
     'assets/images/userImage1.svg',
@@ -42,13 +43,13 @@ class _WhiteContainerUserImageRowListState
   ];
 
   final PageController _pageController = PageController();
-  int _currentPage = 0;
+  int _currentPage = 0; // 현재 이미지 페이지
 
   @override
   void initState() {
     super.initState();
     _pageController.addListener(() {
-      int next = _pageController.page!.round();
+      final next = _pageController.page?.round() ?? 0;
       if (_currentPage != next) {
         setState(() {
           _currentPage = next;
@@ -63,9 +64,37 @@ class _WhiteContainerUserImageRowListState
     super.dispose();
   }
 
+  Future<void> _selectImage(int imageIndex) async {
+    if (imageIndex == 0) { // 카메라 이미지
+      // 카메라 선택
+      final imagePath = await Navigator.push<String>(
+        context,
+        MaterialPageRoute(
+          builder: (context) => CameraView(imageSource: ImageSource.camera),
+        ),
+      );
+      if (imagePath != null && imagePath.isNotEmpty) {
+        widget.onImageSelected(imagePath);
+      }
+    } else if (imageIndex == 4) { // 갤러리 이미지
+      // 갤러리 선택
+      final imagePath = await Navigator.push<String>(
+        context,
+        MaterialPageRoute(
+          builder: (context) => CameraView(imageSource: ImageSource.gallery),
+        ),
+      );
+      if (imagePath != null && imagePath.isNotEmpty) {
+        widget.onImageSelected(imagePath);
+      }
+    } else { // 0, 4 제외한 나머지 이미지
+      widget.onImageSelected(userImagePaths[imageIndex]);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    int pageCount = (userImagePaths.length / 8).ceil();
+    final pageCount = (userImagePaths.length / 8).ceil(); // 한 페이지 당 이미지 개수
 
     return Expanded(
       child: Column(
@@ -77,9 +106,9 @@ class _WhiteContainerUserImageRowListState
               itemBuilder: (context, pageIndex) {
                 return GridView.builder(
                   gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 4,
-                    crossAxisSpacing: 28.w,
-                    mainAxisSpacing: 13.h,
+                    crossAxisCount: 4, // 가로 이미지 개수
+                    crossAxisSpacing: 28.w, // 가로 이미지 간격
+                    mainAxisSpacing: 13.h, // 세로 이미지 간격
                   ),
                   physics: NeverScrollableScrollPhysics(),
                   padding: EdgeInsets.only(
@@ -93,15 +122,15 @@ class _WhiteContainerUserImageRowListState
                     final imageIndex = pageIndex * 8 + index;
                     if (imageIndex < userImagePaths.length) {
                       return GestureDetector(
-                        onTap: () {
-                          widget.onImageSelected(userImagePaths[imageIndex]);
+                        onTap: () async {
+                          await _selectImage(imageIndex);
                         },
                         child: Container(
                           decoration: BoxDecoration(
                             borderRadius: BorderRadius.circular(200.0),
                           ),
                           child: Center(
-                            child: SvgPicture.asset(
+                            child: SvgPicture.asset( // 가로 슬라이드에 이미지 출력
                               userImagePaths[imageIndex],
                               width: 50.sp,
                               height: 50.sp,
@@ -116,7 +145,8 @@ class _WhiteContainerUserImageRowListState
               },
             ),
           ),
-          // 페이지 수 및 현재 페이지 위치
+
+          // 이미지 슬라이드 페이지 위치 및 페이지 수 확인
           Padding(
             padding: EdgeInsets.only(bottom: 0.h),
             child: Row(

--- a/client/front/lib/widgets/text/button_text.dart
+++ b/client/front/lib/widgets/text/button_text.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
+// 갈색 버튼 흰색 텍스트
 Text buttonText(String text)
 {
   return Text(
@@ -10,6 +11,21 @@ Text buttonText(String text)
       fontFamily: 'Pretendard',
       fontWeight: FontWeight.w600,
       color: Color(0xFFFFFFFF),
+      letterSpacing: 0.01,
+    ),
+  );
+}
+
+// 흰색 버튼 검정 텍스트
+Text whiteButtonText(String text)
+{
+  return Text(
+    text,
+    style: TextStyle(
+      fontSize: 15.sp,
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w600, //Semi-bold
+      color: Color(0xFF3E3E3E),
       letterSpacing: 0.01,
     ),
   );


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> ex) #245 

### 📝 주요 작업 내용
> 회원 정보 페이지의 프로필 이미지를 선택하는 기능을 구현했습니다.

1. 회원 정보 페이지
<img src="https://github.com/user-attachments/assets/4670a157-c541-4fb0-9d34-4448a6f89b39" width="150" height="340">

2. 프로필 이미지 클릭
<img src="https://github.com/user-attachments/assets/e8e90070-2849-4b22-8f17-1f579cee0f4a" width="150" height="340">

=> 아래에서 위로 올라오는 슬라이드로 만들었습니다.

3. 슬라이드 구현
   1) 슬라이드 내용 흰색 컨테이너 구현
   2) 미리 보기 프로필 이미지 구현
   3) 프로필 이미지 선택 목록 구현(가로 슬라이드)
   4) 지우기, 저장 버튼 구현(저장 버튼 클릭 시, 회원 정보 페이지의 프로필 이미지에 반영됨)

<img src="https://github.com/user-attachments/assets/4d1b5a3e-ae32-4422-94c6-2ce80726a1d2" width="150" height="340">
<img src="https://github.com/user-attachments/assets/bc56b5d2-c7c6-4a53-ab42-df20e1190b86" width="150" height="340">
<img src="https://github.com/user-attachments/assets/1cac9791-a4f1-4855-8f26-dcc4bcdbe2d2" width="150" height="340">

=> 슬라이드에서 프로필 이미지 선택 목록에서 이미지를 선택할 수 있도록 총 3개의 페이지에서 가로 슬라이드를 통해 여러 이미지를 볼 수 있도록 하였습니다. 몇 번째 슬라이드인지 이미지 아래의 세 개의 점의 색을 통해 확인할 수 있습니다.

<img src="https://github.com/user-attachments/assets/4b01e381-25d2-40b0-a51e-956b4530aa1f" width="150" height="340">
<img src="https://github.com/user-attachments/assets/0f547379-638c-4153-9b67-0e4eb73adf58" width="150" height="340">

=> 이미지를 선택하면 미리보기 프로필 이미지에 선택한 이미지가 반영됩니다. 지우기 버튼을 클릭하면 선택한 이미지가 회원 정보 페이지의 이미지에 반영되지 않고 사라집니다. 선택 후, 저장 버튼을 클릭하면 회원 정보 페이지의 이미지에 저장한 이미지가 반영됩니다. 그러나, 기존의 프로필 이미지가 다른 이미지 였을 때, 다른 이미지를 고른 후, 지우기 버튼을 클릭하면, 기존의 다른 이미지가 그대로 남아있어야 하는데, 기본 프로필로 변경되며 지워집니다. 이 부분은 아직 미완성이라 개선이 필요합니다.

4. 카메라 이동
<img src="https://github.com/user-attachments/assets/e7bd1d02-f38b-4055-870d-d53c51417941" width="150" height="340">
<img src="https://github.com/user-attachments/assets/57092a7b-d144-42f1-9344-1444a6c1a3cb" width="150" height="340">

=> 카메라 구현 했지만, 선택 후 그 이미지가 프로필 이미지에 반영되지 않고 있습니다.

5.  갤러리 이동
<img src="https://github.com/user-attachments/assets/805138a2-0837-4c9c-bb76-b81b4db1d560" width="150" height="340">

=> 갤러리 이미지 선택은 가능하지만, 이미지가 프로필 이미지에 반영되지 않고 있습니다.

=> 카메라, 갤러리에서 선택한 이미지가 반영되도록 구현할 예정입니다.

휴후ㅜ 드디어 카메라, 갤러리에서 선택한 이미지가 미리보기 이미지에 반영되는게 성공!! 파라미터로 받는 값을 bool값도 넘겨줬어야 했는데 이걸 잘 몰랐었나보다,,,
이제 좀 더 다듬어서 완벽하게 만들어 보겠습니당
<img src="https://github.com/user-attachments/assets/1a628dc4-be6b-4f97-9bc7-c612500d6293" width="150" height="340">

6. 카메라, 갤러리 이미지 선택 후, 미리 보기에 반영 및 회원 정보 페이지에 반영
<img src="https://github.com/user-attachments/assets/fb3ede08-33b1-4f6e-8d79-8a1a25145516" width="150" height="340">
<img src="https://github.com/user-attachments/assets/3ada8690-909b-4ef6-a0fd-5316ebb6f143" width="150" height="340">

=> 이미지 선택 시, 반영되게 만들었고, 크기와 모양을 정해주었습니다. 사용자가 미리 보기 이미지 부분을 위치를 조정할 수 없는 것이 조금 아쉽지만, 이 기능은 추후 도전해보겠습니다. 서버에 프로필 이미지를 저장하기만 하면, 사용자 프로필 이미지가 이 페이지를 나가더라도 사라지지 않을 것 같습니다.

### 💬 리뷰 요구사항 
> 잘 되는지 확인 부탁드립니당